### PR TITLE
fix: store cache specific to the evm-version of profile

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,6 +15,7 @@ fs_permissions = [
   { access = "read", path = "./zkout" },
 ]
 evm_version = 'london'
+cache_path = 'cache/london'
 
 [profile.zksync]
 src = 'zksync'
@@ -26,6 +27,7 @@ optimizer_runs = 200
 fs_permissions = [{ access = "write", path = "./reports" }]
 ffi = true
 evm_version = 'shanghai'
+cache_path = 'cache/shanghai'
 
 [profile.zksync.zksync]
 bytecode_hash = 'none'
@@ -36,18 +38,23 @@ zksolc = '1.5.13'
 
 [profile.test]
 evm_version = 'cancun'
+cache_path = 'cache/cancun'
 
 [profile.deploy]
 evm_version = 'london' # due to linea
+cache_path = 'cache/london'
 
 [profile.sonic]
 evm_version = 'cancun'
+cache_path = 'cache/cancun'
 
 [profile.soneium]
 evm_version = 'cancun'
+cache_path = 'cache/cancun'
 
 [profile.celo]
 evm_version = 'cancun'
+cache_path = 'cache/cancun'
 
 [rpc_endpoints]
 mainnet = "${RPC_MAINNET}"
@@ -69,4 +76,4 @@ celo = "${RPC_CELO}"
 sonic = "${RPC_SONIC}"
 soneium = "${RPC_SONEIUM}"
 
-# See more config options https://github.com/gakonst/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config


### PR DESCRIPTION
With different evm-version profiles for deploying and testing, when switching from the test profile to deploy profile, we re-compile everything as the evm-version changes and it is a bit pain.

We now store the compiler cache per evm-version, so when switch back and forth between different foundry profiles we don't have to re-compile everything saving us a bit of time