### PR TITLE
fix: generator imports

### DIFF
--- a/generator/utils/importsResolver.ts
+++ b/generator/utils/importsResolver.ts
@@ -3,6 +3,8 @@
  * Therefore instead of maintaining imports, we just extract them from the generated code instead.
  */
 
+import {POOLS} from '../types';
+
 const GovernanceImports = [
   'GovV3Helpers',
   'IPayloadsControllerCore',
@@ -19,7 +21,7 @@ function generateAddressBookImports(code: string) {
   let root = '';
   // lookbehind for I to not match interfaces like IAaveV3ConfigEngine
   const addressBookMatch = code.match(/(?<!I)(AaveV[2..3][A-Za-z]+)(?<!(Assets)|(EModes))\b\./);
-  if (addressBookMatch) {
+  if (addressBookMatch && (POOLS as readonly string[]).includes(addressBookMatch[1])) {
     imports.push(addressBookMatch[1]);
     root = addressBookMatch[1];
   }


### PR DESCRIPTION
Validates that the address book import generated using regex is valid from the list of pools. 

For ex. if we have the following code match `AaveV3LineaInstance` from regex, we will only generate the import if indeed `AaveV3LineaInstance` is a valid pool name which it is not so we skip.