### PR TITLE
Add Fluid as a Flashborrower: Polygon and Avalanche

### DIFF
--- a/diffs/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903_before_AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903_after.md
+++ b/diffs/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903_before_AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903_after.md
@@ -1,0 +1,32 @@
+## Raw diff
+
+```json
+{
+  "raw": {
+    "0x1140cb7cafacc745771c2ea31e7b5c653c5d0b80": {
+      "label": "GovernanceV3Avalanche.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x0d4058d6b6bac28a1c06101425f18eb1ca62098acfc503f321647be92939156d": {
+          "previousValue": "0x0068b7ccd9000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068b7ccd9000000000003000000000000000000000000000000000000000000"
+        },
+        "0x0d4058d6b6bac28a1c06101425f18eb1ca62098acfc503f321647be92939156e": {
+          "previousValue": "0x000000000000000000093a8000000000000068e5f15a00000000000000000000",
+          "newValue": "0x000000000000000000093a8000000000000068e5f15a00000000000068b7ccda"
+        }
+      }
+    },
+    "0xa72636cbcaa8f5ff95b2cc47f3cdee83f3294a0b": {
+      "label": "AaveV3Avalanche.ACL_MANAGER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x9c162b2b19a4ea7a7dbe9f7a69ab3e515b3362bd561b9fac960b995004b147cf": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        }
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903_before_AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903_after.md
+++ b/diffs/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903_before_AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903_after.md
@@ -1,0 +1,32 @@
+## Raw diff
+
+```json
+{
+  "raw": {
+    "0x401b5d0294e23637c18fcc38b1bca814cda2637c": {
+      "label": "GovernanceV3Polygon.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x4f927caeb3971f91fa48df6c469df5f4f4dedc93d1908f816f25a660193dc171": {
+          "previousValue": "0x0068b7cccf000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068b7cccf000000000003000000000000000000000000000000000000000000"
+        },
+        "0x4f927caeb3971f91fa48df6c469df5f4f4dedc93d1908f816f25a660193dc172": {
+          "previousValue": "0x000000000000000000093a8000000000000068e5f15000000000000000000000",
+          "newValue": "0x000000000000000000093a8000000000000068e5f15000000000000068b7ccd0"
+        }
+      }
+    },
+    "0xa72636cbcaa8f5ff95b2cc47f3cdee83f3294a0b": {
+      "label": "AaveV3Polygon.ACL_MANAGER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x9c162b2b19a4ea7a7dbe9f7a69ab3e515b3362bd561b9fac960b995004b147cf": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Avalanche} from 'aave-address-book/AaveV3Avalanche.sol';
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+
+/**
+ * @title Add Fluid Protocol to flashBorrowers
+ * @author @TokenLogic
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x5e13f3e63fd9a2d4d00ff9f7915644e48d4b8b35fe03b52a599b4bc1c95914d0
+ * - Discussion: https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007
+ */
+contract AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903 is IProposalGenericExecutor {
+  address public constant FLUID_PROTOCOL = 0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7;
+
+  function execute() external {
+    AaveV3Avalanche.ACL_MANAGER.addFlashBorrower(FLUID_PROTOCOL);
+  }
+}

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol
@@ -11,6 +11,7 @@ import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGen
  * - Discussion: https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007
  */
 contract AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903 is IProposalGenericExecutor {
+  // https://snowtrace.io/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
   address public constant FLUID_PROTOCOL = 0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7;
 
   function execute() external {

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.t.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+import {AaveV3Avalanche} from 'aave-address-book/AaveV3Avalanche.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903} from './AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol';
+
+/**
+ * @dev Test for AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.t.sol -vv
+ */
+contract AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903_Test is ProtocolV3TestBase {
+  AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('avalanche'), 68093040);
+    proposal = new AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903',
+      AaveV3Avalanche.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_isFlashBorrower() external {
+    GovV3Helpers.executePayload(vm, address(proposal));
+    bool isFlashBorrower = AaveV3Avalanche.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL());
+    assertEq(isFlashBorrower, true);
+  }
+}

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.t.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.t.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.8.0;
 
 import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
 import {AaveV3Avalanche} from 'aave-address-book/AaveV3Avalanche.sol';
-
-import 'forge-std/Test.sol';
-import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
 import {AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903} from './AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol';
 
 /**
@@ -32,8 +30,8 @@ contract AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903_Test is Proto
   }
 
   function test_isFlashBorrower() external {
+    assertFalse(AaveV3Avalanche.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL()));
     GovV3Helpers.executePayload(vm, address(proposal));
-    bool isFlashBorrower = AaveV3Avalanche.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL());
-    assertEq(isFlashBorrower, true);
+    assertTrue(AaveV3Avalanche.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL()));
   }
 }

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol
@@ -11,6 +11,7 @@ import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGen
  * - Discussion: https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007
  */
 contract AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903 is IProposalGenericExecutor {
+  // https://polygonscan.com/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
   address public constant FLUID_PROTOCOL = 0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7;
 
   function execute() external {

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Polygon} from 'aave-address-book/AaveV3Polygon.sol';
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+
+/**
+ * @title Add Fluid Protocol to flashBorrowers
+ * @author @TokenLogic
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x5e13f3e63fd9a2d4d00ff9f7915644e48d4b8b35fe03b52a599b4bc1c95914d0
+ * - Discussion: https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007
+ */
+contract AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903 is IProposalGenericExecutor {
+  address public constant FLUID_PROTOCOL = 0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7;
+
+  function execute() external {
+    AaveV3Polygon.ACL_MANAGER.addFlashBorrower(FLUID_PROTOCOL);
+  }
+}

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.t.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+import {AaveV3Polygon} from 'aave-address-book/AaveV3Polygon.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903} from './AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol';
+
+/**
+ * @dev Test for AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.t.sol -vv
+ */
+contract AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903_Test is ProtocolV3TestBase {
+  AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('polygon'), 75989845);
+    proposal = new AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903',
+      AaveV3Polygon.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_isFlashBorrower() external {
+    GovV3Helpers.executePayload(vm, address(proposal));
+    bool isFlashBorrower = AaveV3Polygon.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL());
+    assertEq(isFlashBorrower, true);
+  }
+}

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.t.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.t.sol
@@ -3,9 +3,7 @@ pragma solidity ^0.8.0;
 
 import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
 import {AaveV3Polygon} from 'aave-address-book/AaveV3Polygon.sol';
-
-import 'forge-std/Test.sol';
-import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
 import {AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903} from './AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol';
 
 /**
@@ -32,8 +30,8 @@ contract AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903_Test is Protoco
   }
 
   function test_isFlashBorrower() external {
+    assertFalse(AaveV3Polygon.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL()));
     GovV3Helpers.executePayload(vm, address(proposal));
-    bool isFlashBorrower = AaveV3Polygon.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL());
-    assertEq(isFlashBorrower, true);
+    assertTrue(AaveV3Polygon.ACL_MANAGER.isFlashBorrower(proposal.FLUID_PROTOCOL()));
   }
 }

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md
@@ -20,7 +20,7 @@ Whitelist Fluid Protocol as part of FlashBorrowers of Aave v3 on Polygon & Avala
 - Polygon: [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://polygonscan.com/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7)
 - Avalanche: [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://snowtrace.io/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7)
 
-This proposal aims to implement a single AIP, utilizing two similar payloads (one for each network), which will call addFlashBorrower() on the ACL_MANAGER contract.
+This proposal aims to implement a single AIP, utilizing two similar payloads (one for each network), which will call `addFlashBorrower()` on the `ACL_MANAGER` contract.
 
 The AIP when implemented grants permission to whitelist any Fluid Protocol contract for all use cases, such as leveraged positions, eMode, debt and collateral swaps, with one exception: no smart-contract that migrates a position outside of the Aave ecosystem is eligible for whitelisting.
 

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md
@@ -1,0 +1,35 @@
+---
+title: "Add Fluid Protocol to flashBorrowers"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007"
+snapshot: "https://snapshot.box/#/s:aavedao.eth/proposal/0x5e13f3e63fd9a2d4d00ff9f7915644e48d4b8b35fe03b52a599b4bc1c95914d0"
+---
+
+## Simple Summary
+
+This publication proposes including Fluid Protocol on the Aave v3 Flashborrowers whitelist for Polygon and Avalanche.
+
+## Motivation
+
+Fluid has been a long-standing partner in the Aave ecosystem, providing valuable infrastructure and user interfaces. After the recent tokenswap proposal, the Fluid and TokenLogic teams have been able to grow GHO to 80M in user deposits. This publication extends the flashloan fee waiver to include recent Fluid deployments on Avalanche and Polygon.
+
+## Specification
+
+Whitelist Fluid Protocol as part of FlashBorrowers of Aave v3 on Polygon & Avalanche liquidity pools.
+
+0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
+
+This proposal aims to implement a single AIP, utilizing two similar payloads (one for each network), which will call addFlashBorrower() on the ACL_MANAGER contract.
+
+The AIP when implemented grants permission to whitelist any Fluid Protocol contract for all use cases, such as leveraged positions, eMode, debt and collateral swaps, with one exception: no smart-contract that migrates a position outside of the Aave ecosystem is eligible for whitelisting.
+
+## References
+
+- Implementation: [AaveV3Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol), [AaveV3Avalanche](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol)
+- Tests: [AaveV3Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.t.sol), [AaveV3Avalanche](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.t.sol)
+- [Snapshot](https://snapshot.box/#/s:aavedao.eth/proposal/0x5e13f3e63fd9a2d4d00ff9f7915644e48d4b8b35fe03b52a599b4bc1c95914d0)
+- [Discussion](https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md
@@ -17,7 +17,8 @@ Fluid has been a long-standing partner in the Aave ecosystem, providing valuable
 
 Whitelist Fluid Protocol as part of FlashBorrowers of Aave v3 on Polygon & Avalanche liquidity pools.
 
-0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
+- Polygon: [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://polygonscan.com/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7)
+- Avalanche: [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://snowtrace.io/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7)
 
 This proposal aims to implement a single AIP, utilizing two similar payloads (one for each network), which will call addFlashBorrower() on the ACL_MANAGER contract.
 

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers_20250903.s.sol
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers_20250903.s.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+
+import {EthereumScript, PolygonScript, AvalancheScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903} from './AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903.sol';
+import {AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903} from './AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903.sol';
+
+/**
+ * @dev Deploy Polygon
+ * deploy-command: make deploy-ledger contract=src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers_20250903.s.sol:DeployPolygon chain=polygon
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AddFluidProtocolToFlashBorrowers_20250903.s.sol/137/run-latest.json
+ */
+contract DeployPolygon is PolygonScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Deploy Avalanche
+ * deploy-command: make deploy-ledger contract=src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers_20250903.s.sol:DeployAvalanche chain=avalanche
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AddFluidProtocolToFlashBorrowers_20250903.s.sol/43114/run-latest.json
+ */
+contract DeployAvalanche is AvalancheScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers_20250903.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](2);
+
+    // compose actions for validation
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsPolygon = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsPolygon[0] = GovV3Helpers.buildAction(
+        type(AaveV3Polygon_AddFluidProtocolToFlashBorrowers_20250903).creationCode
+      );
+      payloads[0] = GovV3Helpers.buildPolygonPayload(vm, actionsPolygon);
+    }
+
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsAvalanche = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsAvalanche[0] = GovV3Helpers.buildAction(
+        type(AaveV3Avalanche_AddFluidProtocolToFlashBorrowers_20250903).creationCode
+      );
+      payloads[1] = GovV3Helpers.buildAvalanchePayload(vm, actionsAvalanche);
+    }
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20250903_Multi_AddFluidProtocolToFlashBorrowers/AddFluidProtocolToFlashBorrowers.md'
+      )
+    );
+  }
+}

--- a/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/config.ts
+++ b/src/20250903_Multi_AddFluidProtocolToFlashBorrowers/config.ts
@@ -1,0 +1,24 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Polygon', 'AaveV3Avalanche'],
+    title: 'Add Fluid Protocol to flashBorrowers',
+    shortName: 'AddFluidProtocolToFlashBorrowers',
+    date: '20250903',
+    author: '@TokenLogic',
+    discussion: 'https://governance.aave.com/t/arfc-add-fluid-protocol-to-flashborrowers/23007',
+    snapshot:
+      'https://snapshot.box/#/s:aavedao.eth/proposal/0x5e13f3e63fd9a2d4d00ff9f7915644e48d4b8b35fe03b52a599b4bc1c95914d0',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {
+    AaveV3Polygon: {
+      configs: {FLASH_BORROWER: {address: '0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7'}},
+      cache: {blockNumber: 75989845},
+    },
+    AaveV3Avalanche: {
+      configs: {FLASH_BORROWER: {address: '0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7'}},
+      cache: {blockNumber: 68093040},
+    },
+  },
+};


### PR DESCRIPTION
# Changelog

Add Fluid protocol as a flashborrower on Polygon and Avalanche networks.