### PR TITLE
Plasma add fluid flashborrower

### DIFF
--- a/diffs/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014_before_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014_after.md
+++ b/diffs/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014_before_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014_after.md
@@ -1,0 +1,32 @@
+## Raw diff
+
+```json
+{
+  "raw": {
+    "0xa860355f0ccfdc823f7332ac108317b2a1509c06": {
+      "label": "AaveV3Plasma.ACL_MANAGER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x9c162b2b19a4ea7a7dbe9f7a69ab3e515b3362bd561b9fac960b995004b147cf": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        }
+      }
+    },
+    "0xe76eb348e65ef163d85ce282125ff5a7f5712a1d": {
+      "label": "GovernanceV3Plasma.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0xcbc4e5fb02c3d1de23a9f1e014b4d2ee5aeaea9505df5e855c9210bf472495af": {
+          "previousValue": "0x0068ee6be2000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068ee6be2000000000003000000000000000000000000000000000000000000"
+        },
+        "0xcbc4e5fb02c3d1de23a9f1e014b4d2ee5aeaea9505df5e855c9210bf472495b0": {
+          "previousValue": "0x000000000000000000093a80000000000000691c906300000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000691c906300000000000068ee6be3"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.sol
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Plasma} from 'aave-address-book/AaveV3Plasma.sol';
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+
+/**
+ * @title Add Fluid Protocol to flashBorrowers on Plasma
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/direct-to-aip-add-fluid-protocol-to-flashborrowers-on-plasma/23252
+ */
+contract AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014 is
+  IProposalGenericExecutor
+{
+  //https://plasmascan.to/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
+  address public constant NEW_FLASH_BORROWER = 0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7;
+
+  function execute() external {
+    AaveV3Plasma.ACL_MANAGER.addFlashBorrower(NEW_FLASH_BORROWER);
+  }
+}

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.t.sol
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+import {AaveV3Plasma} from 'aave-address-book/AaveV3Plasma.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014} from './AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.sol';
+
+/**
+ * @dev Test for AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.t.sol -vv
+ */
+contract AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014_Test is ProtocolV3TestBase {
+  AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('plasma'), 3526245);
+    proposal = new AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014',
+      AaveV3Plasma.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_isFlashBorrower() external {
+    GovV3Helpers.executePayload(vm, address(proposal));
+    bool isFlashBorrower = AaveV3Plasma.ACL_MANAGER.isFlashBorrower(proposal.NEW_FLASH_BORROWER());
+    assertEq(isFlashBorrower, true);
+  }
+}

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md
@@ -16,15 +16,7 @@ Futher details about Fluid Protocol: https://fluid.io/
 
 ## Specification
 
-Whitelist Fluid Protocol as part of FlashBorrowers of Aave v3 on Plasma liquidity pools.
-
-//https://plasmascan.to/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
-
-0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
-
-This proposal aims to implement an AIP which will call addFlashBorrower() on the ACL_MANAGER contract.
-
-The AIP when implemented grants permission to whitelist any Fluid Protocol contract for all use cases, such as leveraged positions, eMode, debt and collateral swaps, with one exception: no smart-contract that migrates a position outside of the Aave ecosystem is eligible for whitelisting.
+This proposal aims to implement a single AIP, which will call `addFlashBorrower()` on the `ACL_MANAGER` contract to whitelist `0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7` as an eligible contract.
 
 ## References
 

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md
@@ -12,7 +12,7 @@ This proposal includes Fluid Protocol on the Aave v3 Flashborrowers whitelist fo
 
 Fluid has been a long-standing partner in the Aave ecosystem, providing valuable infrastructure and user interfaces. This publication extends the flashloan fee waiver to include recent Fluid deployment on Plasma.
 
-Futher details about Fluid Protocol: https://fluid.io/
+Further details about Fluid Protocol: https://fluid.io/
 
 ## Specification
 

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md
@@ -1,0 +1,38 @@
+---
+title: "Add Fluid Protocol to flashBorrowers on Plasma"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/direct-to-aip-add-fluid-protocol-to-flashborrowers-on-plasma/23252"
+---
+
+## Simple Summary
+
+This proposal includes Fluid Protocol on the Aave v3 Flashborrowers whitelist for Plasma.
+
+## Motivation
+
+Fluid has been a long-standing partner in the Aave ecosystem, providing valuable infrastructure and user interfaces. This publication extends the flashloan fee waiver to include recent Fluid deployment on Plasma.
+
+Futher details about Fluid Protocol: https://fluid.io/
+
+## Specification
+
+Whitelist Fluid Protocol as part of FlashBorrowers of Aave v3 on Plasma liquidity pools.
+
+//https://plasmascan.to/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
+
+0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7
+
+This proposal aims to implement an AIP which will call addFlashBorrower() on the ACL_MANAGER contract.
+
+The AIP when implemented grants permission to whitelist any Fluid Protocol contract for all use cases, such as leveraged positions, eMode, debt and collateral swaps, with one exception: no smart-contract that migrates a position outside of the Aave ecosystem is eligible for whitelisting.
+
+## References
+
+- Implementation: [AaveV3Plasma](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.sol)
+- Tests: [AaveV3Plasma](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.t.sol)
+- Snapshot: Direct-to-AIP
+- [Discussion](https://governance.aave.com/t/direct-to-aip-add-fluid-protocol-to-flashborrowers-on-plasma/23252)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma_20251014.s.sol
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma_20251014.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+
+import {EthereumScript, PlasmaScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014} from './AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014.sol';
+
+/**
+ * @dev Deploy Plasma
+ * deploy-command: make deploy-ledger contract=src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma_20251014.s.sol:DeployPlasma chain=plasma
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AddFluidProtocolToFlashBorrowersOnPlasma_20251014.s.sol/9745/run-latest.json
+ */
+contract DeployPlasma is PlasmaScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma_20251014.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsPlasma = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsPlasma[0] = GovV3Helpers.buildAction(
+        type(AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma_20251014).creationCode
+      );
+      payloads[0] = GovV3Helpers.buildPlasmaPayload(vm, actionsPlasma);
+    }
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/AddFluidProtocolToFlashBorrowersOnPlasma.md'
+      )
+    );
+  }
+}

--- a/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/config.ts
+++ b/src/20251014_AaveV3Plasma_AddFluidProtocolToFlashBorrowersOnPlasma/config.ts
@@ -1,0 +1,20 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Plasma'],
+    title: 'Add Fluid Protocol to flashBorrowers on Plasma',
+    shortName: 'AddFluidProtocolToFlashBorrowersOnPlasma',
+    date: '20251014',
+    author: '@TokenLogic',
+    discussion:
+      'https://governance.aave.com/t/direct-to-aip-add-fluid-protocol-to-flashborrowers-on-plasma/23252',
+    snapshot: 'Direct-to-AIP',
+    votingNetwork: 'AVALANCHE',
+  },
+  poolOptions: {
+    AaveV3Plasma: {
+      configs: {FLASH_BORROWER: {address: '0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7'}},
+      cache: {blockNumber: 3526245},
+    },
+  },
+};


### PR DESCRIPTION
This PR introduces a payload to whitelist the Fluid Protocol contract as a flashBorrower on Aave v3 Plasma.
The change grants Fluid permission to access flashloans from Plasma liquidity pools without paying the standard flashloan fee.

Whitelist Fluid Protocol as part of FlashBorrowers of Aave v3 on Plasma liquidity pools.

New FlashBorrower: [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://plasmascan.to/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7)