### PR TITLE
Renew umbrella reward allowances

### DIFF
--- a/diffs/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201_before_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201_after.md
+++ b/diffs/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201_before_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201_after.md
@@ -1,0 +1,72 @@
+## Raw diff
+
+```json
+{
+  "raw": {
+    "0x23878914efe38d27c4d67ab83ed1b93a74d4086a": {
+      "label": "AaveV3Ethereum.ASSETS.USDT.A_TOKEN",
+      "contract": "lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0x01c9c093a42548bf84b985087695c7f3f44bf6fc749b27d4da3882aa15e6d318": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000008dd19df49d",
+          "newValue": "0x0000000000000000000000000000000000000000000000000000023334f6d29d"
+        }
+      }
+    },
+    "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f": {
+      "label": "AaveV3Ethereum.ASSETS.GHO.UNDERLYING, AaveV3EthereumHorizon.ASSETS.GHO.UNDERLYING, AaveV3EthereumLido.ASSETS.GHO.UNDERLYING, GhoEthereum.GHO_TOKEN, UmbrellaEthereum.UMBRELLA_STAKE_ASSETS.STK_GHO_V1.UNDERLYING",
+      "contract": null,
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0x057bc95533f05aeeb8c6de3359b5992e75a5fe675666a9e63e38e41104bea560": {
+          "previousValue": "0x00000000000000000000000000000000000000000000211fa01dd25b2e362649",
+          "newValue": "0x000000000000000000000000000000000000000000009e702343603dcdaa2649"
+        }
+      }
+    },
+    "0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8": {
+      "label": "AaveV3Ethereum.ASSETS.WETH.A_TOKEN",
+      "contract": "lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0x01c9c093a42548bf84b985087695c7f3f44bf6fc749b27d4da3882aa15e6d318": {
+          "previousValue": "0x000000000000000000000000000000000000000000000008e0d13796dcca110a",
+          "newValue": "0x00000000000000000000000000000000000000000000001791b29fc50fa6110a"
+        }
+      }
+    },
+    "0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c": {
+      "label": "AaveV3Ethereum.ASSETS.USDC.A_TOKEN",
+      "contract": "lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0x01c9c093a42548bf84b985087695c7f3f44bf6fc749b27d4da3882aa15e6d318": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000005887063e26",
+          "newValue": "0x000000000000000000000000000000000000000000000000000001640e6e1f26"
+        }
+      }
+    },
+    "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
+      "contract": "lib/aave-helpers/lib/aave-address-book/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0xd6209e3e3321d5ffded79c758ae1554dd2f9916af03cb81a843ed73242b86577": {
+          "previousValue": "0x00692d1582000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x00692d1582000000000003000000000000000000000000000000000000000000"
+        },
+        "0xd6209e3e3321d5ffded79c758ae1554dd2f9916af03cb81a843ed73242b86578": {
+          "previousValue": "0x000000000000000000093a80000000000000695b3a0300000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000695b3a03000000000000692d1583"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol
@@ -17,10 +17,10 @@ import {UmbrellaEthereum} from 'aave-address-book/UmbrellaEthereum.sol';
  */
 contract AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201 is IProposalGenericExecutor {
   /// @notice Additional allowance for stkwaEthUSDC.v1 rewards (USDC, 6 decimals).
-  uint256 public constant USDC_RENEWAL_ALLOWANCE = 1_149_028 * 1e6;
+  uint256 public constant USDC_RENEWAL_ALLOWANCE = 1_149_028e6;
 
   /// @notice Additional allowance for stkwaEthUSDT.v1 rewards (USDT, 6 decimals).
-  uint256 public constant USDT_RENEWAL_ALLOWANCE = 1_809_848 * 1e6;
+  uint256 public constant USDT_RENEWAL_ALLOWANCE = 1_809_848e6;
 
   /// @notice Additional allowance for stkwaEthWETH.v1 rewards (WETH, 18 decimals).
   uint256 public constant WETH_RENEWAL_ALLOWANCE = 271 ether;
@@ -35,45 +35,32 @@ contract AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201 is IProposalG
     address collector = address(AaveV3Ethereum.COLLECTOR);
     address rewardsController = UmbrellaEthereum.UMBRELLA_REWARDS_CONTROLLER;
 
-    uint256 currentUsdcAllowance = IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).allowance(
-      collector,
-      rewardsController
-    );
-    uint256 currentUsdtAllowance = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(
-      collector,
-      rewardsController
-    );
-    uint256 currentWethAllowance = IERC20(AaveV3EthereumAssets.WETH_A_TOKEN).allowance(
-      collector,
-      rewardsController
-    );
-    uint256 currentGhoAllowance = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
-      collector,
-      rewardsController
-    );
-
     AaveV3Ethereum.COLLECTOR.approve(
       IERC20(AaveV3EthereumAssets.USDC_A_TOKEN),
       rewardsController,
-      currentUsdcAllowance + USDC_RENEWAL_ALLOWANCE
+      IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).allowance(collector, rewardsController) +
+        USDC_RENEWAL_ALLOWANCE
     );
 
     AaveV3Ethereum.COLLECTOR.approve(
       IERC20(AaveV3EthereumAssets.USDT_A_TOKEN),
       rewardsController,
-      currentUsdtAllowance + USDT_RENEWAL_ALLOWANCE
+      IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(collector, rewardsController) +
+        USDT_RENEWAL_ALLOWANCE
     );
 
     AaveV3Ethereum.COLLECTOR.approve(
       IERC20(AaveV3EthereumAssets.WETH_A_TOKEN),
       rewardsController,
-      currentWethAllowance + WETH_RENEWAL_ALLOWANCE
+      IERC20(AaveV3EthereumAssets.WETH_A_TOKEN).allowance(collector, rewardsController) +
+        WETH_RENEWAL_ALLOWANCE
     );
 
     AaveV3Ethereum.COLLECTOR.approve(
       IERC20(AaveV3EthereumAssets.GHO_UNDERLYING),
       rewardsController,
-      currentGhoAllowance + GHO_RENEWAL_ALLOWANCE
+      IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(collector, rewardsController) +
+        GHO_RENEWAL_ALLOWANCE
     );
   }
 }

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {UmbrellaEthereum} from 'aave-address-book/UmbrellaEthereum.sol';
+
+/**
+ * @title Renewal of Umbrella Reward Allowances
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/direct-to-aip-renewal-of-umbrella-reward-allowances/23474
+ * @notice Payload that renews the Umbrella reward allowances from the Aave Ethereum
+ *         Collector to the Umbrella Rewards Controller, so that emissions can
+ *         continue at the current rate without interruption.
+ */
+contract AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201 is IProposalGenericExecutor {
+  /// @notice Additional allowance for stkwaEthUSDC.v1 rewards (USDC, 6 decimals).
+  uint256 public constant USDC_RENEWAL_ALLOWANCE = 1_149_028 * 1e6;
+
+  /// @notice Additional allowance for stkwaEthUSDT.v1 rewards (USDT, 6 decimals).
+  uint256 public constant USDT_RENEWAL_ALLOWANCE = 1_809_848 * 1e6;
+
+  /// @notice Additional allowance for stkwaEthWETH.v1 rewards (WETH, 18 decimals).
+  uint256 public constant WETH_RENEWAL_ALLOWANCE = 271 ether;
+
+  /// @notice Additional allowance for stkGHO.v1 rewards (GHO, 18 decimals).
+  uint256 public constant GHO_RENEWAL_ALLOWANCE = 591_781 ether;
+
+  /// @notice Renews the Collector -> Umbrella Rewards Controller allowances
+  ///         by adding the configured renewal amounts on top of the existing
+  ///         allowances for each reward asset.
+  function execute() external override {
+    address collector = address(AaveV3Ethereum.COLLECTOR);
+    address rewardsController = UmbrellaEthereum.UMBRELLA_REWARDS_CONTROLLER;
+
+    uint256 currentUsdcAllowance = IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 currentUsdtAllowance = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 currentWethAllowance = IERC20(AaveV3EthereumAssets.WETH_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 currentGhoAllowance = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      collector,
+      rewardsController
+    );
+
+    AaveV3Ethereum.COLLECTOR.approve(
+      IERC20(AaveV3EthereumAssets.USDC_A_TOKEN),
+      rewardsController,
+      currentUsdcAllowance + USDC_RENEWAL_ALLOWANCE
+    );
+
+    AaveV3Ethereum.COLLECTOR.approve(
+      IERC20(AaveV3EthereumAssets.USDT_A_TOKEN),
+      rewardsController,
+      currentUsdtAllowance + USDT_RENEWAL_ALLOWANCE
+    );
+
+    AaveV3Ethereum.COLLECTOR.approve(
+      IERC20(AaveV3EthereumAssets.WETH_A_TOKEN),
+      rewardsController,
+      currentWethAllowance + WETH_RENEWAL_ALLOWANCE
+    );
+
+    AaveV3Ethereum.COLLECTOR.approve(
+      IERC20(AaveV3EthereumAssets.GHO_UNDERLYING),
+      rewardsController,
+      currentGhoAllowance + GHO_RENEWAL_ALLOWANCE
+    );
+  }
+}

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.t.sol
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {UmbrellaEthereum} from 'aave-address-book/UmbrellaEthereum.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201} from './AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201
+ * command:
+ *  FOUNDRY_PROFILE=test forge test \
+ *    --match-path=src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.t.sol \
+ *    -vv
+ */
+contract AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201_Test is ProtocolV3TestBase {
+  AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 23916170);
+    proposal = new AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_allowancesBeforeAfter() public {
+    address collector = address(AaveV3Ethereum.COLLECTOR);
+    address rewardsController = UmbrellaEthereum.UMBRELLA_REWARDS_CONTROLLER;
+
+    uint256 usdcBefore = IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 usdtBefore = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 wethBefore = IERC20(AaveV3EthereumAssets.WETH_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 ghoBefore = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      collector,
+      rewardsController
+    );
+
+    executePayload(vm, address(proposal));
+
+    uint256 usdcAfter = IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 usdtAfter = IERC20(AaveV3EthereumAssets.USDT_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 wethAfter = IERC20(AaveV3EthereumAssets.WETH_A_TOKEN).allowance(
+      collector,
+      rewardsController
+    );
+    uint256 ghoAfter = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      collector,
+      rewardsController
+    );
+
+    assertEq(
+      usdcAfter - usdcBefore,
+      proposal.USDC_RENEWAL_ALLOWANCE(),
+      'USDC renewal allowance mismatch'
+    );
+    assertEq(
+      usdtAfter - usdtBefore,
+      proposal.USDT_RENEWAL_ALLOWANCE(),
+      'USDT renewal allowance mismatch'
+    );
+    assertEq(
+      wethAfter - wethBefore,
+      proposal.WETH_RENEWAL_ALLOWANCE(),
+      'WETH renewal allowance mismatch'
+    );
+    assertEq(
+      ghoAfter - ghoBefore,
+      proposal.GHO_RENEWAL_ALLOWANCE(),
+      'GHO renewal allowance mismatch'
+    );
+  }
+}

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances.md
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances.md
@@ -20,6 +20,14 @@ Renewing these allowances ensures that reward distribution continues uninterrupt
 
 Upon implementation, the AIP will **renew the reward allowances** by extending the four Umbrella StakeTokens on **Aave v3 Ethereum Core**.
 
+No changes are proposed to:
+
+- Emission rates
+- Target Liquidity
+- Cooldown parameters
+- Deficit offsets
+- Umbrella architecture
+
 ### New Allowances
 
 Each new allowance equals:
@@ -30,14 +38,6 @@ Each new allowance equals:
 | stkwaEthUSDT.v1 | 1,809,848          | remaining + 1,809,848 |
 | stkwaEthWETH.v1 | 271                | remaining + 271       |
 | stkGHO.v1       | 591,781            | remaining + 591,781   |
-
-No changes are proposed to:
-
-- Emission rates
-- Target Liquidity
-- Cooldown parameters
-- Deficit offsets
-- Umbrella architecture
 
 ## References
 

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances.md
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances.md
@@ -1,0 +1,51 @@
+---
+title: "Renewal of Umbrella Reward Allowances"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/direct-to-aip-renewal-of-umbrella-reward-allowances/23474"
+---
+
+## Simple Summary
+
+This proposal renews the Umbrella reward allowances to support continuing to distribute emissions at the current rate without any disruption to user positions.
+
+## Motivation
+
+Umbrella was activated on June 5th, 2025 and has been performing better than initially modelled. Deposits currently sit around ~$325M, exceeding the original target coverage of ~$261.8M, and providing stronger protection despite less favorable market conditions.
+
+Umbrella rewards are funded through allowances from the Aave Ethereum Collector. The initial allowance configuration—designed to support roughly 6 months of emissions—is now approaching renewal. Based on the most recent 7-day emission rate and the remaining unassigned budget, GHO rewards will require renewing before December 22nd, with other assets requiring updates shortly afterward.
+
+Renewing these allowances ensures that reward distribution continues uninterrupted and that stakers receive emissions at the current rate without disruption.
+
+## Specification
+
+Upon implementation, the AIP will **renew the reward allowances** by extending the four Umbrella StakeTokens on **Aave v3 Ethereum Core**.
+
+### New Allowances
+
+Each new allowance equals:
+
+| Asset           | Original Allowance | New Allowance         |
+| --------------- | ------------------ | --------------------- |
+| stkwaEthUSDC.v1 | 1,149,028          | remaining + 1,149,028 |
+| stkwaEthUSDT.v1 | 1,809,848          | remaining + 1,809,848 |
+| stkwaEthWETH.v1 | 271                | remaining + 271       |
+| stkGHO.v1       | 591,781            | remaining + 591,781   |
+
+No changes are proposed to:
+
+- Emission rates
+- Target Liquidity
+- Cooldown parameters
+- Deficit offsets
+- Umbrella architecture
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.t.sol)
+- Snapshot: Direct-to-AIP
+- [Discussion](https://governance.aave.com/t/direct-to-aip-renewal-of-umbrella-reward-allowances/23474)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances_20251201.s.sol
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances_20251201.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201} from './AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances_20251201.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/RenewalOfUmbrellaRewardAllowances_20251201.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances_20251201.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsEthereum[0] = GovV3Helpers.buildAction(
+        type(AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances_20251201).creationCode
+      );
+      payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+    }
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/RenewalOfUmbrellaRewardAllowances.md'
+      )
+    );
+  }
+}

--- a/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/config.ts
+++ b/src/20251201_AaveV3Ethereum_RenewalOfUmbrellaRewardAllowances/config.ts
@@ -1,0 +1,15 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title: 'Renewal of Umbrella Reward Allowances',
+    shortName: 'RenewalOfUmbrellaRewardAllowances',
+    date: '20251201',
+    author: '@TokenLogic',
+    discussion:
+      'https://governance.aave.com/t/direct-to-aip-renewal-of-umbrella-reward-allowances/23474',
+    snapshot: 'Direct-to-AIP',
+    votingNetwork: 'AVALANCHE',
+  },
+  poolOptions: {AaveV3Ethereum: {configs: {OTHERS: {}}, cache: {blockNumber: 23916170}}},
+};


### PR DESCRIPTION

This PR implements the on-chain payload for the Renewal of Umbrella Reward Allowances Direct-to-AIP.
The proposal extends the reward allowances for the four Umbrella StakeTokens on Aave v3 Ethereum Core, ensuring uninterrupted distribution of emissions at the current rate.

Extends the reward allowances for the following StakeTokens:

- stkwaEthUSDC.v1
- stkwaEthUSDT.v1
- stkwaEthWETH.v1
- stkGHO.v1

[Direct-to-AIP: Renewal of Umbrella Reward Allowances](https://governance.aave.com/t/direct-to-aip-renewal-of-umbrella-reward-allowances/23474)