### PR TITLE
stkAAVE Emission Update

### DIFF
--- a/diffs/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121_before_AaveV3Ethereum_ExtendStkAAVEEmissions_20260121_after.md
+++ b/diffs/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121_before_AaveV3Ethereum_ExtendStkAAVEEmissions_20260121_after.md
@@ -1,0 +1,36 @@
+## Raw diff
+
+```json
+{
+  "raw": {
+    "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9": {
+      "label": "AaveV2Ethereum.ASSETS.AAVE.UNDERLYING, AaveV2EthereumArc.ASSETS.AAVE.UNDERLYING, AaveV3Ethereum.ASSETS.AAVE.UNDERLYING",
+      "contract": "lib/aave-umbrella/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0x4aede0a4429093ac1f64f523c180bcf8485d339a34f665e9c638e9e941c7af2c": {
+          "previousValue": "0x0000000000000000000000000000000000000000000001286b0c8d34aafa6cd8",
+          "newValue": "0x00000000000000000000000000000000000000000000061cef48a2b1377ba9d8"
+        }
+      }
+    },
+    "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
+      "contract": "lib/aave-umbrella/lib/aave-v3-origin/lib/solidity-utils/lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/contracts/proxy/transparent/TransparentUpgradeableProxy.sol:TransparentUpgradeableProxy",
+      "balanceDiff": null,
+      "nonceDiff": null,
+      "stateDiff": {
+        "0xa56be8dc51e2930be3eda04b7b27b0a2f5921a68c355bb74cb7ef787bdf28fac": {
+          "previousValue": "0x006970f732000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x006970f732000000000003000000000000000000000000000000000000000000"
+        },
+        "0xa56be8dc51e2930be3eda04b7b27b0a2f5921a68c355bb74cb7ef787bdf28fad": {
+          "previousValue": "0x000000000000000000093a80000000000000699f1bb300000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000699f1bb30000000000006970f733"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.sol
+++ b/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+import {IStakeToken} from 'aave-helpers/lib/aave-address-book/src/common/IStakeToken.sol';
+import {AaveSafetyModule} from 'aave-address-book/AaveSafetyModule.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+
+/**
+ * @title Extend stkAAVE Emissions
+ * @author @TokenLogic
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x0f73500d0f65c72482d352080ea9aa0aa92264eb059b8f646cf6f0e86556bc3d
+ * - Discussion: https://governance.aave.com/t/arfc-amend-safety-module-emissions/16640/49
+ */
+contract AaveV3Ethereum_ExtendStkAAVEEmissions_20260121 is IProposalGenericExecutor {
+  function execute() external override {
+    (uint128 emissionPerSecond, , ) = IStakeToken(AaveSafetyModule.STK_AAVE).assets(
+      AaveSafetyModule.STK_AAVE
+    );
+
+    uint256 currentAllowance = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).allowance(
+      MiscEthereum.ECOSYSTEM_RESERVE,
+      AaveSafetyModule.STK_AAVE
+    );
+
+    uint256 newAllowance = currentAllowance + (uint256(emissionPerSecond) * 90 days);
+
+    MiscEthereum.AAVE_ECOSYSTEM_RESERVE_CONTROLLER.approve(
+      MiscEthereum.ECOSYSTEM_RESERVE,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      AaveSafetyModule.STK_AAVE,
+      0
+    );
+
+    MiscEthereum.AAVE_ECOSYSTEM_RESERVE_CONTROLLER.approve(
+      MiscEthereum.ECOSYSTEM_RESERVE,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      AaveSafetyModule.STK_AAVE,
+      newAllowance
+    );
+  }
+}

--- a/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.t.sol
+++ b/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_ExtendStkAAVEEmissions_20260121} from './AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.sol';
+import {IStakeToken} from 'aave-address-book/common/IStakeToken.sol';
+import {AaveSafetyModule} from 'aave-address-book/AaveSafetyModule.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_ExtendStkAAVEEmissions_20260121
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.t.sol -vv
+ */
+contract AaveV3Ethereum_ExtendStkAAVEEmissions_20260121_Test is ProtocolV3TestBase {
+  AaveV3Ethereum_ExtendStkAAVEEmissions_20260121 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 24284203);
+    proposal = new AaveV3Ethereum_ExtendStkAAVEEmissions_20260121();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Ethereum_ExtendStkAAVEEmissions_20260121',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_checkConfig() public {
+    (uint128 emissionPerSecondBefore, , ) = IStakeToken(AaveSafetyModule.STK_AAVE).assets(
+      AaveSafetyModule.STK_AAVE
+    );
+
+    assertGt(emissionPerSecondBefore, 0, 'unexpected stkAAVE emission rate before');
+
+    executePayload(vm, address(proposal));
+
+    (uint128 emissionPerSecondAfter, , ) = IStakeToken(AaveSafetyModule.STK_AAVE).assets(
+      AaveSafetyModule.STK_AAVE
+    );
+
+    assertEq(
+      emissionPerSecondAfter,
+      emissionPerSecondBefore,
+      'unexpected stkAAVE emission rate after'
+    );
+  }
+
+  function test_checkAllowance() public {
+    (uint128 stkAaveEmissionPerSecond, , ) = IStakeToken(AaveSafetyModule.STK_AAVE).assets(
+      AaveSafetyModule.STK_AAVE
+    );
+
+    uint256 allowanceBefore = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).allowance(
+      MiscEthereum.ECOSYSTEM_RESERVE,
+      AaveSafetyModule.STK_AAVE
+    );
+
+    uint256 expectedAllowance = allowanceBefore + (uint256(stkAaveEmissionPerSecond) * 90 days);
+
+    executePayload(vm, address(proposal));
+
+    uint256 allowanceAfter = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).allowance(
+      MiscEthereum.ECOSYSTEM_RESERVE,
+      AaveSafetyModule.STK_AAVE
+    );
+
+    assertEq(allowanceAfter, expectedAllowance, 'unexpected stkAAVE allowance after');
+    assertGe(allowanceAfter, allowanceBefore, 'allowance after should be >= allowance before');
+  }
+
+  function test_checkRewards_stkAAVE() public {
+    address stakedToken = AaveV3EthereumAssets.AAVE_UNDERLYING;
+    address staker = 0x5a801a9418D036fD453078c3ADCB761fdc5Ae695;
+    uint256 rewardsPerDay = 260e18;
+
+    executePayload(vm, address(proposal));
+
+    vm.startPrank(staker);
+    IERC20(stakedToken).approve(AaveSafetyModule.STK_AAVE, 1 ether);
+    IERC20(stakedToken).balanceOf(staker);
+    IStakeToken(AaveSafetyModule.STK_AAVE).stake(staker, 1 ether);
+    vm.stopPrank();
+
+    vm.warp(block.timestamp + 1 days);
+
+    uint256 rewardsBalance = IStakeToken(AaveSafetyModule.STK_AAVE).getTotalRewardsBalance(staker);
+
+    assertTrue(rewardsBalance > 0 && rewardsBalance <= rewardsPerDay);
+  }
+}

--- a/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions.md
+++ b/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions.md
@@ -1,0 +1,35 @@
+---
+title: "Extend stkAAVE Emissions"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-amend-safety-module-emissions/16640/49"
+snapshot: "https://snapshot.box/#/s:aavedao.eth/proposal/0x0f73500d0f65c72482d352080ea9aa0aa92264eb059b8f646cf6f0e86556bc3d"
+---
+
+## Simple Summary
+
+Top-up the AAVE allowance for the Safety Module **stkAAVE** to extend rewards distribution by **90 days** while keeping the current emission rate unchanged.
+
+## Motivation
+
+The current stkAAVE allowance from the Ecosystem Reserve is approaching depletion. This proposal renews the allowance to ensure uninterrupted reward distribution for stakers.
+
+**Note:** **stkAAVE is not being phased out**; it will be **repurposed** into a **no-risk staking (dividend yield) contract**.
+
+## Specification
+
+- **Target module:** Safety Module stake token **stkAAVE** (`AaveSafetyModule.STK_AAVE`).
+- **Emission rate:** Unchanged; the payload reads the current `emissionPerSecond` on-chain.
+- **Allowance adjustment (funding):** Reset and set the AAVE allowance from the **Ecosystem Reserve** to cover **remaining allowance** + **90 days** of future emissions:
+  - `allowance = currentAllowance + (emissionPerSecond * 90 days)`
+- **No other changes:** This payload does **not** modify stkAAVE emission rates, cooldown parameters, slashing parameters, or any other Safety Module settings.
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.t.sol)
+- [Snapshot](https://snapshot.box/#/s:aavedao.eth/proposal/0x0f73500d0f65c72482d352080ea9aa0aa92264eb059b8f646cf6f0e86556bc3d)
+- [Discussion](https://governance.aave.com/t/arfc-amend-safety-module-emissions/16640/49)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions_20260121.s.sol
+++ b/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions_20260121.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_ExtendStkAAVEEmissions_20260121} from './AaveV3Ethereum_ExtendStkAAVEEmissions_20260121.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions_20260121.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/ExtendStkAAVEEmissions_20260121.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_ExtendStkAAVEEmissions_20260121).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions_20260121.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsEthereum[0] = GovV3Helpers.buildAction(
+        type(AaveV3Ethereum_ExtendStkAAVEEmissions_20260121).creationCode
+      );
+      payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+    }
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/ExtendStkAAVEEmissions.md'
+      )
+    );
+  }
+}

--- a/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/config.ts
+++ b/src/20260121_AaveV3Ethereum_ExtendStkAAVEEmissions/config.ts
@@ -1,0 +1,15 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title: 'Extend stkAAVE Emissions',
+    shortName: 'ExtendStkAAVEEmissions',
+    date: '20260121',
+    author: '@TokenLogic',
+    discussion: 'https://governance.aave.com/t/arfc-amend-safety-module-emissions/16640/49',
+    snapshot:
+      'https://snapshot.box/#/s:aavedao.eth/proposal/0x0f73500d0f65c72482d352080ea9aa0aa92264eb059b8f646cf6f0e86556bc3d',
+    votingNetwork: 'AVALANCHE',
+  },
+  poolOptions: {AaveV3Ethereum: {configs: {OTHERS: {}}, cache: {blockNumber: 24284203}}},
+};


### PR DESCRIPTION
### Pre-review checklist:

- [ ] I have run a spell check on the write-up and made sure no typos exist.
- [ ] References to Snapshot/governance forum are correct on the AIP. If no snapshot exists, make sure no TODO's exist.
- [ ] The specification on the writeup is aligned with the forum, snapshot, and the payload contract. If there are any changes, they are explicitly mentioned/communicated.
- [ ] Minimal tests exist, and the snapshot diff report generated is the latest one and aligned with the payload.
- [ ] If deploy scripts are manually updated from the generated ones, I have carefully validated that they are correct, including the deploy commands and the proposal-creation script.
- [ ] If the aave-helpers submodule is updated, I have validated it is pointing to the latest version.
- [ ] I have validated that no unused files and imports are being added.
- [ ] For an asset listing, the write-up includes a detailed specification of the price feed used, CAPO adapters (with each CAPO layer described separately), and eModes (with tables) if changed.
- [ ] Wherever possible, I have validated that addresses from the address book are used instead of raw addresses.


This proposal extends the stkAAVE reward distribution by topping up the AAVE allowance from the Ecosystem Reserve with an additional 90 days worth of emissions. 