### PR TITLE
feat: Renew LlamaRisk as Risk Service Provider Epoch 4

### DIFF
--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.sol
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+import {CollectorUtils} from 'aave-helpers/src/CollectorUtils.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+
+/**
+ * @title Renew LlamaRisk as Risk Service Provider - Epoch 4
+ * @author LlamaRisk
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x139144f55e87579003f5f9ed53fc4b87bd0c7312fc9c356e5e4e164baa3f8077
+ * - Discussion: https://governance.aave.com/t/arfc-renew-llamarisk-as-risk-service-provider-epoch-4/24446
+ */
+contract AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513 is
+  IProposalGenericExecutor
+{
+  address public constant LLAMA_RISK = 0x9eE16dBDE572886342fc1e2Db8525DEFB007b27c;
+
+  uint256 public constant PREVIOUS_STREAM = 100071;
+
+  uint256 public constant STREAM_DURATION = 365 days;
+
+  uint256 public constant BULK_AMOUNT = 1_500_000 ether;
+  uint256 public constant GHO_STREAM_AMOUNT = 1_500_000 ether;
+  uint256 public constant AAVE_STREAM_AMOUNT = 5_000 ether;
+
+  function execute() external {
+    AaveV3EthereumLido.COLLECTOR.cancelStream(PREVIOUS_STREAM);
+
+    AaveV3EthereumLido.COLLECTOR.transfer(
+      IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN),
+      LLAMA_RISK,
+      BULK_AMOUNT
+    );
+
+    CollectorUtils.stream(
+      AaveV3EthereumLido.COLLECTOR,
+      CollectorUtils.CreateStreamInput({
+        underlying: AaveV3EthereumLidoAssets.GHO_A_TOKEN,
+        receiver: LLAMA_RISK,
+        amount: GHO_STREAM_AMOUNT,
+        start: block.timestamp,
+        duration: STREAM_DURATION
+      })
+    );
+
+    uint256 aaveStreamAmount = (AAVE_STREAM_AMOUNT / STREAM_DURATION) * STREAM_DURATION;
+    MiscEthereum.AAVE_ECOSYSTEM_RESERVE_CONTROLLER.createStream(
+      MiscEthereum.ECOSYSTEM_RESERVE,
+      LLAMA_RISK,
+      aaveStreamAmount,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      block.timestamp,
+      block.timestamp + STREAM_DURATION
+    );
+  }
+}

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.t.sol
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.t.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+import {IStreamable} from 'aave-address-book/common/IStreamable.sol';
+import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513} from './AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.sol';
+
+/**
+ * @dev Test for AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.t.sol -vv
+ */
+contract AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513_Test is
+  ProtocolV3TestBase
+{
+  uint256 internal constant MAX_DELTA_STREAM_BALANCE = 0.00001e18;
+
+  AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 25088434);
+    proposal = new AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513',
+      AaveV3EthereumLido.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_previousStreamCanceled() public {
+    uint256 streamId = proposal.PREVIOUS_STREAM();
+    AaveV3EthereumLido.COLLECTOR.getStream(streamId);
+
+    executePayload(vm, address(proposal));
+
+    vm.expectRevert();
+    AaveV3EthereumLido.COLLECTOR.getStream(streamId);
+  }
+
+  function test_bulkTransfer() public {
+    uint256 balanceBefore = IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN).balanceOf(
+      proposal.LLAMA_RISK()
+    );
+
+    executePayload(vm, address(proposal));
+
+    uint256 balanceAfter = IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN).balanceOf(
+      proposal.LLAMA_RISK()
+    );
+
+    assertGe(balanceAfter - balanceBefore, proposal.BULK_AMOUNT());
+  }
+
+  function test_ghoStreamCreated() public {
+    address receiver = proposal.LLAMA_RISK();
+    uint256 nextStreamId = AaveV3EthereumLido.COLLECTOR.getNextStreamId();
+
+    vm.expectRevert();
+    AaveV3EthereumLido.COLLECTOR.getStream(nextStreamId);
+
+    executePayload(vm, address(proposal));
+
+    (
+      address sender,
+      address streamReceiver,
+      uint256 deposit,
+      address tokenAddress,
+      uint256 startTime,
+      uint256 stopTime,
+      ,
+
+    ) = AaveV3EthereumLido.COLLECTOR.getStream(nextStreamId);
+
+    assertEq(sender, address(AaveV3EthereumLido.COLLECTOR));
+    assertEq(streamReceiver, receiver);
+    assertEq(tokenAddress, AaveV3EthereumLidoAssets.GHO_A_TOKEN);
+    assertEq(stopTime - startTime, proposal.STREAM_DURATION());
+    assertApproxEqRel(deposit, proposal.GHO_STREAM_AMOUNT(), MAX_DELTA_STREAM_BALANCE);
+  }
+
+  function test_ghoStreamPartialWithdraw() public {
+    address receiver = proposal.LLAMA_RISK();
+    uint256 nextStreamId = AaveV3EthereumLido.COLLECTOR.getNextStreamId();
+
+    executePayload(vm, address(proposal));
+
+    vm.warp(block.timestamp + 1 days);
+
+    uint256 balanceBefore = IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN).balanceOf(receiver);
+
+    vm.prank(receiver);
+    AaveV3EthereumLido.COLLECTOR.withdrawFromStream(nextStreamId, 1);
+
+    uint256 balanceAfter = IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN).balanceOf(receiver);
+    assertEq(balanceAfter, balanceBefore + 1);
+  }
+
+  function test_ghoStreamEndBalance() public {
+    address receiver = proposal.LLAMA_RISK();
+    uint256 nextStreamId = AaveV3EthereumLido.COLLECTOR.getNextStreamId();
+
+    executePayload(vm, address(proposal));
+
+    vm.warp(block.timestamp + proposal.STREAM_DURATION());
+
+    uint256 streamable = AaveV3EthereumLido.COLLECTOR.balanceOf(nextStreamId, receiver);
+    assertApproxEqRel(streamable, proposal.GHO_STREAM_AMOUNT(), MAX_DELTA_STREAM_BALANCE);
+
+    uint256 balanceBefore = IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN).balanceOf(receiver);
+
+    vm.prank(receiver);
+    AaveV3EthereumLido.COLLECTOR.withdrawFromStream(nextStreamId, streamable);
+
+    uint256 balanceAfter = IERC20(AaveV3EthereumLidoAssets.GHO_A_TOKEN).balanceOf(receiver);
+    assertApproxEqRel(
+      balanceAfter,
+      balanceBefore + proposal.GHO_STREAM_AMOUNT(),
+      MAX_DELTA_STREAM_BALANCE
+    );
+  }
+
+  function test_aaveStreamCreated() public {
+    IStreamable reserve = IStreamable(MiscEthereum.ECOSYSTEM_RESERVE);
+    address receiver = proposal.LLAMA_RISK();
+    uint256 nextStreamId = reserve.getNextStreamId();
+    uint256 expectedAmount = (proposal.AAVE_STREAM_AMOUNT() / proposal.STREAM_DURATION()) *
+      proposal.STREAM_DURATION();
+
+    vm.expectRevert();
+    reserve.getStream(nextStreamId);
+
+    executePayload(vm, address(proposal));
+
+    (
+      address sender,
+      address streamReceiver,
+      uint256 deposit,
+      address tokenAddress,
+      uint256 startTime,
+      uint256 stopTime,
+      ,
+
+    ) = reserve.getStream(nextStreamId);
+
+    assertEq(sender, MiscEthereum.ECOSYSTEM_RESERVE);
+    assertEq(streamReceiver, receiver);
+    assertEq(tokenAddress, AaveV3EthereumAssets.AAVE_UNDERLYING);
+    assertEq(stopTime - startTime, proposal.STREAM_DURATION());
+    assertEq(deposit, expectedAmount);
+  }
+
+  function test_aaveStreamPartialWithdraw() public {
+    IStreamable reserve = IStreamable(MiscEthereum.ECOSYSTEM_RESERVE);
+    address receiver = proposal.LLAMA_RISK();
+    uint256 nextStreamId = reserve.getNextStreamId();
+
+    executePayload(vm, address(proposal));
+
+    vm.warp(block.timestamp + 1 days);
+
+    uint256 balanceBefore = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).balanceOf(receiver);
+
+    vm.prank(receiver);
+    reserve.withdrawFromStream(nextStreamId, 1);
+
+    uint256 balanceAfter = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).balanceOf(receiver);
+    assertEq(balanceAfter, balanceBefore + 1);
+  }
+
+  function test_aaveStreamEndBalance() public {
+    IStreamable reserve = IStreamable(MiscEthereum.ECOSYSTEM_RESERVE);
+    address receiver = proposal.LLAMA_RISK();
+    uint256 nextStreamId = reserve.getNextStreamId();
+    uint256 expectedAmount = (proposal.AAVE_STREAM_AMOUNT() / proposal.STREAM_DURATION()) *
+      proposal.STREAM_DURATION();
+
+    executePayload(vm, address(proposal));
+
+    vm.warp(block.timestamp + proposal.STREAM_DURATION());
+
+    uint256 streamable = reserve.balanceOf(nextStreamId, receiver);
+    assertEq(streamable, expectedAmount);
+
+    uint256 balanceBefore = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).balanceOf(receiver);
+
+    vm.prank(receiver);
+    reserve.withdrawFromStream(nextStreamId, streamable);
+
+    uint256 balanceAfter = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).balanceOf(receiver);
+    assertEq(balanceAfter, balanceBefore + expectedAmount);
+  }
+}

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.t.sol
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
 import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
 import {IStreamable} from 'aave-address-book/common/IStreamable.sol';

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
@@ -1,0 +1,32 @@
+---
+title: "Renew LlamaRisk as Risk Service Provider - Epoch 4"
+author: "LlamaRisk"
+discussions: "https://governance.aave.com/t/arfc-renew-llamarisk-as-risk-service-provider-epoch-4/24446"
+snapshot: "https://snapshot.box/#/s:aavedao.eth/proposal/0x139144f55e87579003f5f9ed53fc4b87bd0c7312fc9c356e5e4e164baa3f8077"
+---
+
+## Simple Summary
+
+## Motivation
+
+## Specification
+
+The payload performs the following actions on Ethereum mainnet:
+
+- Cancel the existing GHO stream (ID `100071`) on `AaveV3EthereumLido.COLLECTOR`.
+- Transfer `1,500,000 aEthLidoGHO` from `AaveV3EthereumLido.COLLECTOR` to the LlamaRisk-controlled multisig at `0x9eE16dBDE572886342fc1e2Db8525DEFB007b27c`.
+- Create a new `aEthLidoGHO` stream of `1,500,000` over `365 days` to the same recipient, via `CollectorUtils.stream()` on `AaveV3EthereumLido.COLLECTOR`.
+- Create a new `AAVE` stream of `5,000` over `365 days` to the same recipient, via `AAVE_ECOSYSTEM_RESERVE_CONTROLLER.createStream()` on `MiscEthereum.ECOSYSTEM_RESERVE`. The stream amount is rounded down to the nearest multiple of the duration to avoid revert in the underlying controller.
+
+## References
+
+- Forum discussion: https://governance.aave.com/t/arfc-renew-llamarisk-as-risk-service-provider-epoch-4/24446
+- Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x139144f55e87579003f5f9ed53fc4b87bd0c7312fc9c356e5e4e164baa3f8077
+
+## Disclaimer
+
+LlamaRisk receives compensation from the Aave DAO for serving as a Risk Service Provider, as specified in this proposal.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
@@ -35,11 +35,11 @@ LlamaRisk is currently a team of 16 contributors and expects to scale to 20+ con
 
 The approved compensation structure is:
 
-| Component | Amount | Payment Method |
-| --- | ---: | --- |
-| Upfront payment | 1,500,000 GHO | Immediate payment |
+| Component        |        Amount | Payment Method              |
+| ---------------- | ------------: | --------------------------- |
+| Upfront payment  | 1,500,000 GHO | Immediate payment           |
 | Streamed payment | 1,500,000 GHO | Linear stream over one year |
-| Streamed payment | 5,000 AAVE | Linear stream over one year |
+| Streamed payment |    5,000 AAVE | Linear stream over one year |
 
 The current GHO stream with ID `100071` will be terminated.
 

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
@@ -55,8 +55,6 @@ Under this engagement, LlamaRisk will continue supporting Aave risk operations a
 
 The full scope, rationale, and budget were discussed through the ARFC process and approved by Snapshot. This AIP implements the approved renewal terms.
 
-## Motivation
-
 ## Specification
 
 The payload performs the following actions on Ethereum mainnet:

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md
@@ -7,6 +7,54 @@ snapshot: "https://snapshot.box/#/s:aavedao.eth/proposal/0x139144f55e87579003f5f
 
 ## Simple Summary
 
+This AIP renews LlamaRisk as a Risk Service Provider for Aave for one year.
+
+Aave’s risk layer recently lost critical infrastructure operated by a departing risk provider, including automated risk-oracle infrastructure, parameter automation pipelines, and Risk Steward coverage. LlamaRisk stepped in with Aave Labs to assume control of the Risk Steward and maintain operational continuity across Aave markets.
+
+The immediate issue is continuity.
+
+The structural issue is ensuring Aave does not depend on risk infrastructure the DAO cannot inspect, verify, or replace without disruption.
+
+This renewal expands LlamaRisk’s scope across Aave V3, Aave V4, and Horizon, with a focus on protocol-owned risk infrastructure built on Chainlink CRE. This moves Aave’s risk layer toward infrastructure owned and controlled by the DAO, with off-chain logic independently verifiable through cryptographic workflow IDs.
+
+LlamaRisk will deliver:
+
+- Protocol-owned risk infrastructure on Chainlink CRE.
+- Risk-managed price feeds for Pendle PTs, CAPO assets, USDe, RWA NAV, and related integrations.
+- Dynamic parameter automation for supply caps, borrow caps, interest rates, Umbrella calibration, credit lines, risk premiums, and liquidation configuration.
+- Safety mechanisms including freeze guardians and V4 per-Spoke circuit breakers.
+- Risk Steward co-ownership and operational accountability.
+- AIP and governance payload review.
+- Guardian signer duties.
+- Monitoring, dashboards, escalation playbooks, and incident response support.
+- Continued Horizon cooperation and LlamaGuard NAV expansion.
+- R&D for V4-native risk systems, including RWA liquidation infrastructure and instant settlement infrastructure.
+- Legal and regulatory research covering stablecoins, custody, counterparty risk, DeFi lending compliance, and tokenized RWA structuring.
+
+LlamaRisk is currently a team of 16 contributors and expects to scale to 20+ contributors during this engagement. LlamaRisk also proposes to phase out remaining non-Aave work over six months and become Aave-exclusive by the midpoint of the engagement.
+
+The approved compensation structure is:
+
+| Component | Amount | Payment Method |
+| --- | ---: | --- |
+| Upfront payment | 1,500,000 GHO | Immediate payment |
+| Streamed payment | 1,500,000 GHO | Linear stream over one year |
+| Streamed payment | 5,000 AAVE | Linear stream over one year |
+
+The current GHO stream with ID `100071` will be terminated.
+
+## Motivation
+
+This proposal renews LlamaRisk as a Risk Service Provider for Aave following DAO discussion and Snapshot approval.
+
+LlamaRisk’s role has expanded beyond its original mandate and now covers risk work across Aave V3, Aave V4, Horizon, governance review, market monitoring, Guardian signer duties, and protocol-owned risk infrastructure.
+
+The renewal also addresses a near-term continuity need. With a departing risk provider no longer covering critical risk infrastructure and operational processes, the DAO needs to maintain coverage across active markets while reducing reliance on closed systems that are difficult for the DAO to inspect, verify, or replace.
+
+Under this engagement, LlamaRisk will continue supporting Aave risk operations and contribute to protocol-owned risk infrastructure, including Chainlink CRE-based risk oracles, dynamic parameter tooling, LlamaGuard expansion, V4-native risk systems, and Horizon-related risk work.
+
+The full scope, rationale, and budget were discussed through the ARFC process and approved by Snapshot. This AIP implements the approved renewal terms.
+
 ## Motivation
 
 ## Specification

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.s.sol
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.s.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513} from './AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513).creationCode
+    );
+
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4_20260513).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/RenewLlamaRiskAsRiskServiceProviderEpoch4.md'
+      )
+    );
+  }
+}

--- a/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/config.ts
+++ b/src/20260513_AaveV3EthereumLido_RenewLlamaRiskAsRiskServiceProviderEpoch4/config.ts
@@ -1,0 +1,16 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    author: 'LlamaRisk',
+    pools: ['AaveV3EthereumLido'],
+    title: 'Renew LlamaRisk as Risk Service Provider - Epoch 4',
+    shortName: 'RenewLlamaRiskAsRiskServiceProviderEpoch4',
+    date: '20260513',
+    discussion:
+      'https://governance.aave.com/t/arfc-renew-llamarisk-as-risk-service-provider-epoch-4/24446',
+    snapshot:
+      'https://snapshot.box/#/s:aavedao.eth/proposal/0x139144f55e87579003f5f9ed53fc4b87bd0c7312fc9c356e5e4e164baa3f8077',
+    votingNetwork: 'AVALANCHE',
+  },
+  poolOptions: {AaveV3EthereumLido: {configs: {OTHERS: {}}, cache: {blockNumber: 25088434}}},
+};


### PR DESCRIPTION
Renews LlamaRisk as Risk Service Provider for Epoch 4, per the passed snapshot vote.

- Forum: https://governance.aave.com/t/arfc-renew-llamarisk-as-risk-service-provider-epoch-4/24446
- Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x139144f55e87579003f5f9ed53fc4b87bd0c7312fc9c356e5e4e164baa3f8077

### Payload actions (`AaveV3EthereumLido`)

- Cancels the previous GHO stream (ID `100071`) on `AaveV3EthereumLido.COLLECTOR`.
- Transfers `1,500,000` aEthLidoGHO upfront to the LlamaRisk multisig `0x9eE16dBDE572886342fc1e2Db8525DEFB007b27c`.
- Creates a `1,500,000` aEthLidoGHO stream over `365 days` to the same recipient via `CollectorUtils.stream()`.
- Creates a `5,000` AAVE stream over `365 days` from `MiscEthereum.ECOSYSTEM_RESERVE` via `AAVE_ECOSYSTEM_RESERVE_CONTROLLER.createStream()` (amount rounded down to a multiple of the duration to avoid the underlying controller revert).

### Notes

- AIP write-up (Simple Summary, Motivation) is intentionally left blank; the prose is being prepared separately by Collin and will be filled in before the merge. The Specification section already mirrors the on-chain payload behavior.

### Pre-review checklist

- [x] Spell check on the write-up.
- [x] Snapshot and governance forum references are correct on the AIP. No TODOs.
- [ ] Specification on the writeup is aligned with the forum, snapshot, and the payload contract (Specification section aligned; Simple Summary / Motivation pending Collin).
- [x] Minimal tests exist; snapshot diff will be produced by CI.
- [x] Deploy scripts validated against the generated convention; deploy/proposal-creation commands present in natspec.
- [x] `aave-helpers` submodule untouched.
- [x] No unused files/imports.
- [ ] N/A — not an asset listing.
- [x] Addresses pulled from `aave-address-book` wherever possible (`LLAMA_RISK` multisig and `PREVIOUS_STREAM` id are the only raw constants).