### PR TITLE
Update stkAave Emissions payload

### DIFF
--- a/src/20260505_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260505.sol
+++ b/src/20260505_AaveV3Ethereum_ExtendStkAAVEEmissions/AaveV3Ethereum_ExtendStkAAVEEmissions_20260505.sol
@@ -16,12 +16,12 @@ import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
  */
 contract AaveV3Ethereum_ExtendStkAAVEEmissions_20260505 is IProposalGenericExecutor {
   function execute() external override {
-    (uint128 emissionPerSecond, , ) = IStakeToken(AaveSafetyModule.STK_AAVE).assets(
+    uint256 currentAllowance = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).allowance(
+      MiscEthereum.ECOSYSTEM_RESERVE,
       AaveSafetyModule.STK_AAVE
     );
 
-    uint256 currentAllowance = IERC20(AaveV3EthereumAssets.AAVE_UNDERLYING).allowance(
-      MiscEthereum.ECOSYSTEM_RESERVE,
+    (uint128 emissionPerSecond, , ) = IStakeToken(AaveSafetyModule.STK_AAVE).assets(
       AaveSafetyModule.STK_AAVE
     );
 


### PR DESCRIPTION
Changing the order of the functions to generate different bytecode:

STATICCALL(allowance)
STATICCALL(assets)

will generate different bytecode than

STATICCALL(assets)
STATICCALL(allowance)

this is needed cor create2() as otherwise, it will add to our payload the exact contract that was done in january (same create2 address).