### PR TITLE
Restore WETH LTV Levels

### DIFF
--- a/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.sol
+++ b/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IProposalGenericExecutor} from 'aave-helpers/src/interfaces/IProposalGenericExecutor.sol';
+import {AaveV3InkWhitelabel, AaveV3InkWhitelabelAssets} from 'aave-address-book/AaveV3InkWhitelabel.sol';
+
+/**
+ * @title Restore WETH LTV levels
+ * @author EvanInkFnd
+ */
+contract AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518 is IProposalGenericExecutor {
+  function execute() external {
+    AaveV3InkWhitelabel.POOL_CONFIGURATOR.setReserveLtvzero({
+      asset: AaveV3InkWhitelabelAssets.WETH_UNDERLYING,
+      ltvzero: false
+    });
+  }
+}

--- a/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.t.sol
+++ b/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3InkWhitelabel} from 'aave-address-book/AaveV3InkWhitelabel.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518} from './AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.sol';
+
+/**
+ * @dev Test for AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.t.sol -vv
+ */
+contract AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518_Test is ProtocolV3TestBase {
+  AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('ink'), 45627082);
+    proposal = new AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518',
+      AaveV3InkWhitelabel.POOL,
+      address(proposal),
+      true,
+      true
+    );
+  }
+}

--- a/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/RestoreWETHLTVLevels_20260518.s.sol
+++ b/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/RestoreWETHLTVLevels_20260518.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3InkWhitelabel} from 'aave-address-book/GovernanceV3InkWhitelabel.sol';
+
+import {EthereumScript, InkScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518} from './AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518.sol';
+
+/**
+ * @dev Deploy Ink
+ * deploy-command: make deploy-ledger contract=src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/RestoreWETHLTVLevels_20260518.s.sol:DeployInk chain=ink
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/RestoreWETHLTVLevels_20260518.s.sol/57073/run-latest.json
+ */
+contract DeployInk is InkScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3InkWhitelabel_RestoreWETHLTVLevels_20260518).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPermissionedPayloadCalldata(
+      GovernanceV3InkWhitelabel.PERMISSIONED_PAYLOADS_CONTROLLER,
+      actions
+    );
+  }
+}

--- a/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/config.ts
+++ b/src/20260518_AaveV3InkWhitelabel_RestoreWETHLTVLevels/config.ts
@@ -1,0 +1,12 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3InkWhitelabel'],
+    title: 'Restore WETH LTV levels',
+    author: 'EvanInkFnd',
+    force: true,
+    shortName: 'RestoreWETHLTVLevels',
+    date: '20260518',
+  },
+  poolOptions: {AaveV3InkWhitelabel: {configs: {OTHERS: {}}, cache: {blockNumber: 45627082}}},
+};


### PR DESCRIPTION
Restores WETH collateral LTV on Aave V3 Ink Whitelabel by clearing the `ltvzero` flag for WETH.

Expected state delta:
- WETH LTV: `0` -> `8000`
- Liquidation threshold: unchanged at `8300`
- Liquidation bonus: unchanged at `10750`
- Action: `POOL_CONFIGURATOR.setReserveLtvzero(WETH, false)`

Reference:
- https://governance.aave.com/t/direct-to-aip-weth-unfreeze-and-ltv-restoration-across-aave-v3-instances/24878
