### PR TITLE
Update SolvBTC supply cap to 400

### DIFF
--- a/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.sol
+++ b/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3InkWhitelabelAssets} from 'aave-address-book/AaveV3InkWhitelabel.sol';
+import {AaveV3PayloadInkWhitelabel} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadInkWhitelabel.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title update SolvBTC supply cap to 400
+ * @author EvanInkFnd
+ */
+contract AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520 is AaveV3PayloadInkWhitelabel {
+  function capsUpdates() public pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capsUpdate = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capsUpdate[0] = IAaveV3ConfigEngine.CapsUpdate({
+      asset: AaveV3InkWhitelabelAssets.SolvBTC_UNDERLYING,
+      supplyCap: 400,
+      borrowCap: EngineFlags.KEEP_CURRENT
+    });
+
+    return capsUpdate;
+  }
+}

--- a/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.t.sol
+++ b/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3InkWhitelabel} from 'aave-address-book/AaveV3InkWhitelabel.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520} from './AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.sol';
+
+/**
+ * @dev Test for AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.t.sol -vv
+ */
+contract AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520_Test is ProtocolV3TestBase {
+  AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('ink'), 45824470);
+    proposal = new AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520',
+      AaveV3InkWhitelabel.POOL,
+      address(proposal),
+      true,
+      true
+    );
+  }
+}

--- a/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/UpdateSolvBTCSupplyCapTo400_20260520.s.sol
+++ b/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/UpdateSolvBTCSupplyCapTo400_20260520.s.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3InkWhitelabel} from 'aave-address-book/GovernanceV3InkWhitelabel.sol';
+
+import {EthereumScript, InkScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520} from './AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520.sol';
+
+/**
+ * @dev Deploy Ink
+ * deploy-command: make deploy-ledger contract=src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/UpdateSolvBTCSupplyCapTo400_20260520.s.sol:DeployInk chain=ink
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/UpdateSolvBTCSupplyCapTo400_20260520.s.sol/57073/run-latest.json
+ */
+contract DeployInk is InkScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400_20260520).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPermissionedPayloadCalldata(
+      GovernanceV3InkWhitelabel.PERMISSIONED_PAYLOADS_CONTROLLER,
+      actions
+    );
+  }
+}

--- a/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/config.ts
+++ b/src/20260520_AaveV3InkWhitelabel_UpdateSolvBTCSupplyCapTo400/config.ts
@@ -1,0 +1,16 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3InkWhitelabel'],
+    title: 'update SolvBTC supply cap to 400',
+    shortName: 'UpdateSolvBTCSupplyCapTo400',
+    date: '20260520',
+    author: 'EvanInkFnd',
+  },
+  poolOptions: {
+    AaveV3InkWhitelabel: {
+      configs: {CAPS_UPDATE: [{asset: 'SolvBTC', supplyCap: '400', borrowCap: ''}]},
+      cache: {blockNumber: 45824470},
+    },
+  },
+};


### PR DESCRIPTION
Updates SolvBTC supply cap on Aave V3 Ink Whitelabel from 50 to 400

Simulation: https://dashboard.tenderly.co/explorer/vnet/e1da3584-ead2-4134-81b7-3d226f723ecd/transactions