### PR TITLE
feat: enable isolation mode for generated proposal tests

### DIFF
--- a/generator/features/__snapshots__/assetListing.spec.ts.snap
+++ b/generator/features/__snapshots__/assetListing.spec.ts.snap
@@ -195,6 +195,7 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/assetListing.spec.ts.snap
+++ b/generator/features/__snapshots__/assetListing.spec.ts.snap
@@ -194,8 +194,8 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/eModesCreation.spec.ts.snap
+++ b/generator/features/__snapshots__/eModesCreation.spec.ts.snap
@@ -234,6 +234,7 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/eModesCreation.spec.ts.snap
+++ b/generator/features/__snapshots__/eModesCreation.spec.ts.snap
@@ -233,8 +233,8 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/priceFeedsUpdate.spec.ts.snap
+++ b/generator/features/__snapshots__/priceFeedsUpdate.spec.ts.snap
@@ -109,6 +109,7 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/priceFeedsUpdate.spec.ts.snap
+++ b/generator/features/__snapshots__/priceFeedsUpdate.spec.ts.snap
@@ -108,8 +108,8 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/rateUpdates.spec.ts.snap
+++ b/generator/features/__snapshots__/rateUpdates.spec.ts.snap
@@ -214,8 +214,8 @@ contract AaveV2EthereumAMM_Test_20231023_Test is ProtocolV2TestBase {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV2EthereumAMM_Test_20231023', AaveV2EthereumAMM.POOL, address(proposal));
   }

--- a/generator/features/__snapshots__/rateUpdates.spec.ts.snap
+++ b/generator/features/__snapshots__/rateUpdates.spec.ts.snap
@@ -215,6 +215,7 @@ contract AaveV2EthereumAMM_Test_20231023_Test is ProtocolV2TestBase {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV2EthereumAMM_Test_20231023', AaveV2EthereumAMM.POOL, address(proposal));
   }

--- a/generator/features/v4/__snapshots__/allModules.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/allModules.spec.ts.snap
@@ -712,6 +712,7 @@ contract AaveV4Ethereum_V4Every_20260521_Test is ProtocolV4TestBase {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV4Ethereum_V4Every_20260521', address(proposal));
   }

--- a/generator/features/v4/__snapshots__/allModules.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/allModules.spec.ts.snap
@@ -711,8 +711,8 @@ contract AaveV4Ethereum_V4Every_20260521_Test is ProtocolV4TestBase {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV4Ethereum_V4Every_20260521', address(proposal));
   }

--- a/generator/features/v4/__snapshots__/hubSpokeConfigUpdate.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/hubSpokeConfigUpdate.spec.ts.snap
@@ -126,6 +126,7 @@ contract AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521_Test is ProtocolV4Te
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521', address(proposal));
   }

--- a/generator/features/v4/__snapshots__/hubSpokeConfigUpdate.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/hubSpokeConfigUpdate.spec.ts.snap
@@ -125,8 +125,8 @@ contract AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521_Test is ProtocolV4Te
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521', address(proposal));
   }

--- a/generator/features/v4/__snapshots__/useCases.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/useCases.spec.ts.snap
@@ -576,6 +576,7 @@ contract AaveV4Ethereum_V4EveryUseCase_20260521_Test is ProtocolV4TestBase {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV4Ethereum_V4EveryUseCase_20260521', address(proposal));
   }

--- a/generator/features/v4/__snapshots__/useCases.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/useCases.spec.ts.snap
@@ -575,8 +575,8 @@ contract AaveV4Ethereum_V4EveryUseCase_20260521_Test is ProtocolV4TestBase {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     defaultTest('AaveV4Ethereum_V4EveryUseCase_20260521', address(proposal));
   }

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -55,8 +55,8 @@ contract ${contractName}_Test is ${testBase} {
 
   /**
    * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
    */
-  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     ${defaultTestCall}
   }

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -56,6 +56,7 @@ contract ${contractName}_Test is ${testBase} {
   /**
    * @dev executes the generic test suite including e2e and config snapshots
    */
+  /// forge-config: default.isolate = true
   function test_defaultProposalExecution() public {
     ${defaultTestCall}
   }


### PR DESCRIPTION
## What

Emits the inline `/// forge-config: default.isolate = true` annotation on `test_defaultProposalExecution` in the generator template, and regenerates the affected snapshots.

## Why

aave-helpers [#743](https://github.com/aave-dao/aave-helpers/pull/743) reworked the payload gas-limit check in `ProtocolV3TestBase`/`ProtocolV4TestBase` to measure gas under isolation against the real EIP-7825 per-tx cap (`16_777_216`) instead of foundry's overridden `block.gaslimit`. That accurate cold metering only kicks in when the test runs under isolation, which is opted into per-test via the inline annotation.

Adding it to the template means every newly generated proposal test benefits automatically, without a global config change.

## Changes

- `generator/templates/test.template.ts` — add the annotation above `test_defaultProposalExecution`.
- Regenerated the 7 affected `__snapshots__/*.snap` files.

Generator suite passes (`pnpm test`, 43/43).