### PR TITLE
fix: parse voting network as scalar

### DIFF
--- a/generator/cli.spec.ts
+++ b/generator/cli.spec.ts
@@ -1,0 +1,18 @@
+import {Command, Option} from 'commander';
+import {describe, expect, it} from 'vitest';
+import {VOTING_NETWORK} from './types';
+
+describe('voting network option', () => {
+  it('parses the voting network as a scalar', () => {
+    const program = new Command().addOption(
+      new Option(
+        '-v, --votingNetwork <votingNetwork>',
+        'network where voting should take place for the proposal',
+      ).choices(Object.values(VOTING_NETWORK)),
+    );
+
+    program.parse(['node', 'test', '--votingNetwork', 'AVALANCHE']);
+
+    expect(program.opts().votingNetwork).toBe('AVALANCHE');
+  });
+});

--- a/generator/cli.ts
+++ b/generator/cli.ts
@@ -81,7 +81,7 @@ program
   .addOption(new Option('-s, --snapshot <string>', 'snapshot link'))
   .addOption(
     new Option(
-      '-v, --votingNetwork <votingNetwork...>',
+      '-v, --votingNetwork <votingNetwork>',
       'network where voting should take place for the proposal',
     ).choices(Object.values(VOTING_NETWORK)),
   )


### PR DESCRIPTION
Depends on #1152 

## Summary

Fixes `pnpm generate -v/--votingNetwork` so it parses a single voting network value instead of a variadic list.

## Bug

The CLI currently defines the option as variadic:

```ts
new Option('-v, --votingNetwork <votingNetwork...>', 'Voting network to use')
```

So an interactive/non-config generation path using Avalanche produces this in the generated proposal `config.ts`:

```ts
votingNetwork: ['AVALANCHE'],
```

That value is later passed to `getVotingPortal`, which expects a scalar `VOTING_NETWORK` enum value:

```ts
export function getVotingPortal(votingNetwork: VOTING_NETWORK) {
  switch (votingNetwork) {
    case VOTING_NETWORK.ETHEREUM:
      return GovernanceV3Ethereum.VOTING_PORTAL_ETH_ETH;
    case VOTING_NETWORK.AVALANCHE:
      return GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX;
    default:
      return GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL;
  }
}
```

Because `['AVALANCHE'] !== VOTING_NETWORK.AVALANCHE`, the Avalanche case is skipped and the default branch is used. The generated proposal therefore falls back to `GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL`, the Polygon voting portal.

## Fix

Parse `--votingNetwork` as a scalar:

```ts
new Option('-v, --votingNetwork <votingNetwork>', 'Voting network to use')
```

This makes the generated `config.ts` use:

```ts
votingNetwork: 'AVALANCHE',
```

and `getVotingPortal(VOTING_NETWORK.AVALANCHE)` resolves to `GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX`.
