### PR TITLE
fix: update proposal test for v4 in generator

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -2,7 +2,7 @@
   "lib/aave-helpers": {
     "branch": {
       "name": "main",
-      "rev": "b0ecb386f8b3bba70001c68375f632956e831ee4"
+      "rev": "7fc8146643bf360d516fac1fdb6d7da5d1a9cc98"
     }
   },
   "lib/aave-umbrella": {

--- a/generator/common.spec.ts
+++ b/generator/common.spec.ts
@@ -18,7 +18,10 @@ describe('getTestBase', () => {
   it('maps each market family to its test base', () => {
     expect(getTestBase('AaveV2Ethereum')).toEqual({v4: false, testBase: 'ProtocolV2TestBase'});
     expect(getTestBase('AaveV3Ethereum')).toEqual({v4: false, testBase: 'ProtocolV3TestBase'});
-    expect(getTestBase('AaveV4Ethereum')).toEqual({v4: true, testBase: 'ProtocolV4TestBase'});
+    expect(getTestBase('AaveV4Ethereum')).toEqual({
+      v4: true,
+      testBase: 'ProtocolV4TestBaseEthereum',
+    });
   });
 
   it('throws for an unknown market', () => {

--- a/generator/common.ts
+++ b/generator/common.ts
@@ -103,7 +103,8 @@ export function getVersion(market: MarketIdentifier) {
 export function getTestBase(market: MarketIdentifier): {v4: boolean; testBase: string} {
   if (isV2Market(market)) return {v4: false, testBase: 'ProtocolV2TestBase'};
   if (isV3Market(market)) return {v4: false, testBase: 'ProtocolV3TestBase'};
-  if (isV4Market(market)) return {v4: true, testBase: 'ProtocolV4TestBase'};
+  if (isV4Market(market))
+    return {v4: true, testBase: `ProtocolV4TestBase${getMarketChain(market)}`};
   throw new Error(`unknown market version for ${market}`);
 }
 

--- a/generator/features/v4/__snapshots__/allModules.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/allModules.spec.ts.snap
@@ -694,14 +694,14 @@ import {IPositionManagerBase} from 'aave-v4/position-manager/interfaces/IPositio
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
 import 'forge-std/Test.sol';
-import {ProtocolV4TestBase} from 'aave-helpers/src/ProtocolV4TestBase.sol';
+import {ProtocolV4TestBaseEthereum} from 'aave-helpers/src/v4-protocol-test/ProtocolV4TestBaseEthereum.sol';
 import {AaveV4Ethereum_V4Every_20260521} from './AaveV4Ethereum_V4Every_20260521.sol';
 
 /**
  * @dev Test for AaveV4Ethereum_V4Every_20260521
  * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260521_AaveV4Ethereum_V4Every/AaveV4Ethereum_V4Every_20260521.t.sol -vv
  */
-contract AaveV4Ethereum_V4Every_20260521_Test is ProtocolV4TestBase {
+contract AaveV4Ethereum_V4Every_20260521_Test is ProtocolV4TestBaseEthereum {
   AaveV4Ethereum_V4Every_20260521 internal proposal;
 
   function setUp() public {

--- a/generator/features/v4/__snapshots__/hubSpokeConfigUpdate.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/hubSpokeConfigUpdate.spec.ts.snap
@@ -108,14 +108,14 @@ import {AaveV4EthereumHubs, AaveV4EthereumAssets, AaveV4EthereumSpokes} from 'aa
 import {IHub} from 'aave-v4/hub/interfaces/IHub.sol';
 
 import 'forge-std/Test.sol';
-import {ProtocolV4TestBase} from 'aave-helpers/src/ProtocolV4TestBase.sol';
+import {ProtocolV4TestBaseEthereum} from 'aave-helpers/src/v4-protocol-test/ProtocolV4TestBaseEthereum.sol';
 import {AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521} from './AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521.sol';
 
 /**
  * @dev Test for AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521
  * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260521_AaveV4Ethereum_V4HubSpokeConfigUpdateTest/AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521.t.sol -vv
  */
-contract AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521_Test is ProtocolV4TestBase {
+contract AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521_Test is ProtocolV4TestBaseEthereum {
   AaveV4Ethereum_V4HubSpokeConfigUpdateTest_20260521 internal proposal;
 
   function setUp() public {

--- a/generator/features/v4/__snapshots__/useCases.spec.ts.snap
+++ b/generator/features/v4/__snapshots__/useCases.spec.ts.snap
@@ -558,14 +558,14 @@ import {IPositionManagerBase} from 'aave-v4/position-manager/interfaces/IPositio
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 
 import 'forge-std/Test.sol';
-import {ProtocolV4TestBase} from 'aave-helpers/src/ProtocolV4TestBase.sol';
+import {ProtocolV4TestBaseEthereum} from 'aave-helpers/src/v4-protocol-test/ProtocolV4TestBaseEthereum.sol';
 import {AaveV4Ethereum_V4EveryUseCase_20260521} from './AaveV4Ethereum_V4EveryUseCase_20260521.sol';
 
 /**
  * @dev Test for AaveV4Ethereum_V4EveryUseCase_20260521
  * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260521_AaveV4Ethereum_V4EveryUseCase/AaveV4Ethereum_V4EveryUseCase_20260521.t.sol -vv
  */
-contract AaveV4Ethereum_V4EveryUseCase_20260521_Test is ProtocolV4TestBase {
+contract AaveV4Ethereum_V4EveryUseCase_20260521_Test is ProtocolV4TestBaseEthereum {
   AaveV4Ethereum_V4EveryUseCase_20260521 internal proposal;
 
   function setUp() public {

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -27,7 +27,7 @@ export const testTemplate = (
     .join('\n');
 
   const testBaseImport = v4
-    ? `import {${testBase}} from 'aave-helpers/src/${testBase}.sol';`
+    ? `import {${testBase}} from 'aave-helpers/src/v4-protocol-test/${testBase}.sol';`
     : `import {${testBase}, ReserveConfig} from 'aave-helpers/${chain === 'ZkSync' ? 'zksync/src/' : 'src/'}${testBase}.sol';`;
 
   const defaultTestCall = v4


### PR DESCRIPTION
Update generator imports of ProtocolTestBase for V4 proposals after changes in aave-helpers
