### PR TITLE
chore: delete dead percent prompt code

### DIFF
--- a/generator/prompts.spec.ts
+++ b/generator/prompts.spec.ts
@@ -28,7 +28,7 @@ describe('prompts', () => {
     });
   });
 
-  describe('percentInput', () => {
+  describe('percentPrompt', () => {
     it('handles "yes"', async () => {
       const {answer, events, getScreen} = await render(percentPrompt, {
         message: 'Enter number?',

--- a/generator/prompts.ts
+++ b/generator/prompts.ts
@@ -16,10 +16,6 @@ interface GenericPrompt<T extends boolean = boolean> {
   defaultValue?: string;
 }
 
-interface PercentInputPrompt<T extends boolean> extends GenericPrompt<T> {
-  toRay?: boolean;
-}
-
 export type PercentInputValues = typeof ENGINE_FLAGS.KEEP_CURRENT | string;
 
 export type NumberInputValues = typeof ENGINE_FLAGS.KEEP_CURRENT | string;


### PR DESCRIPTION
- remove the unused `PercentInputPrompt` interface
- rename the stale `percentInput` test label to `percentPrompt`