### PR TITLE
feat: generate reserve change assertions

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -2,7 +2,7 @@
   "lib/aave-helpers": {
     "branch": {
       "name": "main",
-      "rev": "0cc9a62cc37c17fe6f079b96a273b9b6cd55a015"
+      "rev": "1165ff370b1efcd6c8c3f5340e4680cef1b96400"
     }
   },
   "lib/aave-umbrella": {

--- a/generator/features/__snapshots__/assetListing.spec.ts.snap
+++ b/generator/features/__snapshots__/assetListing.spec.ts.snap
@@ -200,6 +200,15 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }
 
+  /**
+   * @dev checks whether reserve configurations changed or stayed unchanged as expected
+   */
+  function test_reserveConfigChanges() public {
+    address[] memory updatedAssets = new address[](0);
+
+    reserveConfigChangesTest(AaveV3Ethereum.POOL, address(proposal), updatedAssets);
+  }
+
   function test_dustBinHasPSPFunds() public {
     GovV3Helpers.executePayload(vm, address(proposal));
     address aTokenAddress = AaveV3Ethereum.POOL.getReserveAToken(proposal.PSP());

--- a/generator/features/__snapshots__/capsUpdates.spec.ts.snap
+++ b/generator/features/__snapshots__/capsUpdates.spec.ts.snap
@@ -1,0 +1,50 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`feature: capsUpdates > should return reasonable code 1`] = `
+{
+  "code": {
+    "fn": [
+      "function capsUpdates() public pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+          IAaveV3ConfigEngine.CapsUpdate[] memory capsUpdate = new IAaveV3ConfigEngine.CapsUpdate[](2);
+
+          capsUpdate[0] = IAaveV3ConfigEngine.CapsUpdate({
+               asset: AaveV3EthereumAssets.DAI_UNDERLYING,
+               supplyCap: 1_000_000,
+               borrowCap: EngineFlags.KEEP_CURRENT
+             });
+capsUpdate[1] = IAaveV3ConfigEngine.CapsUpdate({
+               asset: AaveV3EthereumAssets.USDC_UNDERLYING,
+               supplyCap: 2_000_000,
+               borrowCap: 900_000
+             });
+
+          return capsUpdate;
+        }",
+    ],
+  },
+  "test": {
+    "fn": [
+      "function _expectedCapsChanges() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+      IAaveV3ConfigEngine.CapsUpdate[] memory capsUpdate;
+      capsUpdate = new IAaveV3ConfigEngine.CapsUpdate[](2);
+
+      capsUpdate[0] = IAaveV3ConfigEngine.CapsUpdate({
+               asset: AaveV3EthereumAssets.DAI_UNDERLYING,
+               supplyCap: 1_000_000,
+               borrowCap: EngineFlags.KEEP_CURRENT
+             });
+capsUpdate[1] = IAaveV3ConfigEngine.CapsUpdate({
+               asset: AaveV3EthereumAssets.USDC_UNDERLYING,
+               supplyCap: 2_000_000,
+               borrowCap: 900_000
+             });
+      return capsUpdate;
+    }",
+    ],
+    "updatedAssets": [
+      "AaveV3EthereumAssets.DAI_UNDERLYING",
+      "AaveV3EthereumAssets.USDC_UNDERLYING",
+    ],
+  },
+}
+`;

--- a/generator/features/__snapshots__/collateralsUpdates.spec.ts.snap
+++ b/generator/features/__snapshots__/collateralsUpdates.spec.ts.snap
@@ -1,0 +1,58 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`feature: collateralsUpdates > should return reasonable code 1`] = `
+{
+  "code": {
+    "fn": [
+      "function collateralsUpdates() public pure override returns (IAaveV3ConfigEngine.CollateralUpdate[] memory) {
+          IAaveV3ConfigEngine.CollateralUpdate[] memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](2);
+
+          collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+               asset: AaveV3EthereumAssets.DAI_UNDERLYING,
+               ltv: 0,
+               liqThreshold: EngineFlags.KEEP_CURRENT,
+               liqBonus: EngineFlags.KEEP_CURRENT,
+               liqProtocolFee: EngineFlags.KEEP_CURRENT
+             });
+collateralUpdate[1] = IAaveV3ConfigEngine.CollateralUpdate({
+               asset: AaveV3EthereumAssets.USDC_UNDERLYING,
+               ltv: 77_00,
+               liqThreshold: 80_00,
+               liqBonus: 5_00,
+               liqProtocolFee: 10_00
+             });
+
+          return collateralUpdate;
+        }",
+    ],
+  },
+  "test": {
+    "fn": [
+      "function _expectedCollateralChanges() internal pure override returns (IAaveV3ConfigEngine.CollateralUpdate[] memory) {
+      IAaveV3ConfigEngine.CollateralUpdate[] memory collateralUpdate;
+      collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](2);
+
+      collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+               asset: AaveV3EthereumAssets.DAI_UNDERLYING,
+               ltv: 0,
+               liqThreshold: EngineFlags.KEEP_CURRENT,
+               liqBonus: EngineFlags.KEEP_CURRENT,
+               liqProtocolFee: EngineFlags.KEEP_CURRENT
+             });
+collateralUpdate[1] = IAaveV3ConfigEngine.CollateralUpdate({
+               asset: AaveV3EthereumAssets.USDC_UNDERLYING,
+               ltv: 77_00,
+               liqThreshold: 80_00,
+               liqBonus: 5_00,
+               liqProtocolFee: 10_00
+             });
+      return collateralUpdate;
+    }",
+    ],
+    "updatedAssets": [
+      "AaveV3EthereumAssets.DAI_UNDERLYING",
+      "AaveV3EthereumAssets.USDC_UNDERLYING",
+    ],
+  },
+}
+`;

--- a/generator/features/__snapshots__/eModesCreation.spec.ts.snap
+++ b/generator/features/__snapshots__/eModesCreation.spec.ts.snap
@@ -239,6 +239,15 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }
 
+  /**
+   * @dev checks whether reserve configurations changed or stayed unchanged as expected
+   */
+  function test_reserveConfigChanges() public {
+    address[] memory updatedAssets = new address[](0);
+
+    reserveConfigChangesTest(AaveV3Ethereum.POOL, address(proposal), updatedAssets);
+  }
+
   function test_dustBinHasPT_sUSDe_TESTFunds() public {
     GovV3Helpers.executePayload(vm, address(proposal));
     address aTokenAddress = AaveV3Ethereum.POOL.getReserveAToken(proposal.PT_sUSDe_TEST());

--- a/generator/features/__snapshots__/priceFeedsUpdate.spec.ts.snap
+++ b/generator/features/__snapshots__/priceFeedsUpdate.spec.ts.snap
@@ -113,6 +113,15 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
   function test_defaultProposalExecution() public {
     defaultTest('AaveV3Ethereum_Test_20231023', AaveV3Ethereum.POOL, address(proposal));
   }
+
+  /**
+   * @dev checks whether reserve configurations changed or stayed unchanged as expected
+   */
+  function test_reserveConfigChanges() public {
+    address[] memory updatedAssets = new address[](0);
+
+    reserveConfigChangesTest(AaveV3Ethereum.POOL, address(proposal), updatedAssets);
+  }
 }
 ",
     },

--- a/generator/features/borrowsUpdates.spec.ts
+++ b/generator/features/borrowsUpdates.spec.ts
@@ -1,0 +1,29 @@
+import {expect, describe, it} from 'vitest';
+import {borrowsUpdates} from './borrowsUpdates';
+import {MOCK_OPTIONS} from './mocks/configs';
+
+describe('feature: borrowsUpdates', () => {
+  it('declares expected reserve config changes', () => {
+    const output = borrowsUpdates.build({
+      options: MOCK_OPTIONS,
+      market: 'AaveV3Ethereum',
+      cfg: [
+        {
+          asset: 'DAI',
+          enabledToBorrow: 'DISABLED',
+          flashloanable: 'KEEP_CURRENT',
+          reserveFactor: '25',
+        },
+      ],
+      cache: {blockNumber: 42},
+      configs: {},
+    });
+    const test = output.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('function _expectedBorrowChanges()');
+    expect(test).toContain('asset: AaveV3EthereumAssets.DAI_UNDERLYING');
+    expect(test).toContain('enabledToBorrow: EngineFlags.DISABLED');
+    expect(test).toContain('flashloanable: EngineFlags.KEEP_CURRENT');
+    expect(test).toContain('reserveFactor: 25_00');
+  });
+});

--- a/generator/features/borrowsUpdates.ts
+++ b/generator/features/borrowsUpdates.ts
@@ -1,4 +1,4 @@
-import {CodeArtifact, FEATURE, FeatureModule} from '../types';
+import {CodeArtifact, FEATURE, FeatureModule, MarketIdentifier} from '../types';
 import {BorrowUpdate} from './types';
 import {
   assetsSelectPrompt,
@@ -26,6 +26,31 @@ export async function fetchBorrowUpdate<T extends boolean>(required?: T) {
 
 type BorrowUpdates = BorrowUpdate[];
 
+function renderBorrowUpdateEntries(market: MarketIdentifier, cfgs: BorrowUpdates, varName: string) {
+  return cfgs
+    .map(
+      (cfg, ix) => `${varName}[${ix}] = IAaveV3ConfigEngine.BorrowUpdate({
+               asset: ${translateAssetToAssetLibUnderlying(cfg.asset, market)},
+               enabledToBorrow: ${translateJsBoolToSol(cfg.enabledToBorrow)},
+               flashloanable: ${translateJsBoolToSol(cfg.flashloanable)},
+               reserveFactor: ${translateJsPercentToSol(cfg.reserveFactor)}
+             });`,
+    )
+    .join('\n');
+}
+
+function borrowUpdateOverrides(market: MarketIdentifier, cfgs: BorrowUpdates): string[] {
+  return [
+    `function _expectedBorrowChanges() internal pure override returns (IAaveV3ConfigEngine.BorrowUpdate[] memory) {
+      IAaveV3ConfigEngine.BorrowUpdate[] memory borrowUpdates;
+      borrowUpdates = new IAaveV3ConfigEngine.BorrowUpdate[](${cfgs.length});
+
+      ${renderBorrowUpdateEntries(market, cfgs, 'borrowUpdates')}
+      return borrowUpdates;
+    }`,
+  ];
+}
+
 export const borrowsUpdates: FeatureModule<BorrowUpdates> = {
   value: FEATURE.BORROWS_UPDATE,
   description: 'BorrowsUpdates (enabledToBorrow, flashloanable, reserveFactor)',
@@ -50,20 +75,15 @@ export const borrowsUpdates: FeatureModule<BorrowUpdates> = {
             cfg.length
           });
 
-          ${cfg
-            .map(
-              (cfg, ix) => `borrowUpdates[${ix}] = IAaveV3ConfigEngine.BorrowUpdate({
-               asset: ${translateAssetToAssetLibUnderlying(cfg.asset, market)},
-               enabledToBorrow: ${translateJsBoolToSol(cfg.enabledToBorrow)},
-               flashloanable: ${translateJsBoolToSol(cfg.flashloanable)},
-               reserveFactor: ${translateJsPercentToSol(cfg.reserveFactor)}
-             });`,
-            )
-            .join('\n')}
+          ${renderBorrowUpdateEntries(market, cfg, 'borrowUpdates')}
 
           return borrowUpdates;
         }`,
         ],
+      },
+      test: {
+        fn: borrowUpdateOverrides(market, cfg),
+        updatedAssets: cfg.map((cfg) => translateAssetToAssetLibUnderlying(cfg.asset, market)),
       },
     };
     return response;

--- a/generator/features/capsUpdates.spec.ts
+++ b/generator/features/capsUpdates.spec.ts
@@ -1,0 +1,61 @@
+import {expect, describe, it} from 'vitest';
+import {capsUpdates} from './capsUpdates';
+import {MOCK_OPTIONS, capsUpdates as capsUpdatesConfig} from './mocks/configs';
+
+describe('feature: capsUpdates', () => {
+  const output = capsUpdates.build({
+    options: MOCK_OPTIONS,
+    market: 'AaveV3Ethereum',
+    cfg: capsUpdatesConfig,
+    cache: {blockNumber: 42},
+    configs: {},
+  });
+
+  it('should return reasonable code', () => {
+    expect(output).toMatchSnapshot();
+  });
+
+  it('declares updated assets for reserve config validation', () => {
+    expect(output.test?.updatedAssets).toEqual([
+      'AaveV3EthereumAssets.DAI_UNDERLYING',
+      'AaveV3EthereumAssets.USDC_UNDERLYING',
+    ]);
+  });
+
+  it('encodes set fields as values and empty fields as KEEP_CURRENT on the payload struct', () => {
+    const code = (output.code?.fn?.join('\n') ?? '').replace(/\s+/g, ' ');
+    expect(code).toContain(
+      'asset: AaveV3EthereumAssets.DAI_UNDERLYING, supplyCap: 1_000_000, borrowCap: EngineFlags.KEEP_CURRENT',
+    );
+    expect(code).toContain(
+      'asset: AaveV3EthereumAssets.USDC_UNDERLYING, supplyCap: 2_000_000, borrowCap: 900_000',
+    );
+  });
+
+  it('asserts changed cap fields and preserves other reserve config values', () => {
+    const test = output.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('function _expectedCapsChanges()');
+    expect(test).toContain('internal pure override');
+    expect(test).toContain(
+      'asset: AaveV3EthereumAssets.DAI_UNDERLYING,\n               supplyCap: 1_000_000,\n               borrowCap: EngineFlags.KEEP_CURRENT',
+    );
+    expect(test).toContain(
+      'asset: AaveV3EthereumAssets.USDC_UNDERLYING,\n               supplyCap: 2_000_000,\n               borrowCap: 900_000',
+    );
+  });
+
+  it('emits zero cap assignments instead of treating them as KEEP_CURRENT', () => {
+    const zeroOutput = capsUpdates.build({
+      options: MOCK_OPTIONS,
+      market: 'AaveV3Ethereum',
+      cfg: [{asset: 'WETH', supplyCap: '0', borrowCap: '0'}],
+      cache: {blockNumber: 42},
+      configs: {},
+    });
+    const test = zeroOutput.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('supplyCap: 0');
+    expect(test).toContain('borrowCap: 0');
+  });
+});

--- a/generator/features/capsUpdates.ts
+++ b/generator/features/capsUpdates.ts
@@ -1,4 +1,4 @@
-import {CodeArtifact, FEATURE, FeatureModule} from '../types';
+import {CodeArtifact, FEATURE, FeatureModule, MarketIdentifier} from '../types';
 import {CapsUpdate, CapsUpdatePartial} from './types';
 import {
   assetsSelectPrompt,
@@ -20,6 +20,30 @@ export async function fetchCapsUpdate(required?: boolean): Promise<CapsUpdatePar
 }
 
 type CapsUpdates = CapsUpdate[];
+
+function renderCapsUpdateEntries(market: MarketIdentifier, cfgs: CapsUpdates, varName: string) {
+  return cfgs
+    .map(
+      (cfg, ix) => `${varName}[${ix}] = IAaveV3ConfigEngine.CapsUpdate({
+               asset: ${translateAssetToAssetLibUnderlying(cfg.asset, market)},
+               supplyCap: ${translateJsNumberToSol(cfg.supplyCap)},
+               borrowCap: ${translateJsNumberToSol(cfg.borrowCap)}
+             });`,
+    )
+    .join('\n');
+}
+
+function capsUpdateOverrides(market: MarketIdentifier, cfgs: CapsUpdates): string[] {
+  return [
+    `function _expectedCapsChanges() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+      IAaveV3ConfigEngine.CapsUpdate[] memory capsUpdate;
+      capsUpdate = new IAaveV3ConfigEngine.CapsUpdate[](${cfgs.length});
+
+      ${renderCapsUpdateEntries(market, cfgs, 'capsUpdate')}
+      return capsUpdate;
+    }`,
+  ];
+}
 
 export const capsUpdates: FeatureModule<CapsUpdates> = {
   value: FEATURE.CAPS_UPDATE,
@@ -47,19 +71,15 @@ export const capsUpdates: FeatureModule<CapsUpdates> = {
             cfg.length
           });
 
-          ${cfg
-            .map(
-              (cfg, ix) => `capsUpdate[${ix}] = IAaveV3ConfigEngine.CapsUpdate({
-               asset: ${translateAssetToAssetLibUnderlying(cfg.asset, market)},
-               supplyCap: ${translateJsNumberToSol(cfg.supplyCap)},
-               borrowCap: ${translateJsNumberToSol(cfg.borrowCap)}
-             });`,
-            )
-            .join('\n')}
+          ${renderCapsUpdateEntries(market, cfg, 'capsUpdate')}
 
           return capsUpdate;
         }`,
         ],
+      },
+      test: {
+        fn: capsUpdateOverrides(market, cfg),
+        updatedAssets: cfg.map((cfg) => translateAssetToAssetLibUnderlying(cfg.asset, market)),
       },
     };
     return response;

--- a/generator/features/collateralsUpdates.spec.ts
+++ b/generator/features/collateralsUpdates.spec.ts
@@ -1,0 +1,60 @@
+import {expect, describe, it} from 'vitest';
+import {collateralsUpdates} from './collateralsUpdates';
+import {MOCK_OPTIONS, collateralUpdates as collateralUpdatesConfig} from './mocks/configs';
+
+describe('feature: collateralsUpdates', () => {
+  const output = collateralsUpdates.build({
+    options: MOCK_OPTIONS,
+    market: 'AaveV3Ethereum',
+    cfg: collateralUpdatesConfig,
+    cache: {blockNumber: 42},
+    configs: {},
+  });
+
+  it('should return reasonable code', () => {
+    expect(output).toMatchSnapshot();
+  });
+
+  it('encodes set fields as values and empty fields as KEEP_CURRENT on the payload struct', () => {
+    const code = (output.code?.fn?.join('\n') ?? '').replace(/\s+/g, ' ');
+    expect(code).toContain(
+      'asset: AaveV3EthereumAssets.DAI_UNDERLYING, ltv: 0, liqThreshold: EngineFlags.KEEP_CURRENT, liqBonus: EngineFlags.KEEP_CURRENT, liqProtocolFee: EngineFlags.KEEP_CURRENT',
+    );
+    expect(code).toContain(
+      'asset: AaveV3EthereumAssets.USDC_UNDERLYING, ltv: 77_00, liqThreshold: 80_00, liqBonus: 5_00, liqProtocolFee: 10_00',
+    );
+  });
+
+  it('asserts changed collateral fields and preserves other reserve config values', () => {
+    const test = output.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('function _expectedCollateralChanges()');
+    expect(test).toContain('internal pure override');
+    expect(test).toContain(
+      'asset: AaveV3EthereumAssets.DAI_UNDERLYING,\n               ltv: 0,\n               liqThreshold: EngineFlags.KEEP_CURRENT,\n               liqBonus: EngineFlags.KEEP_CURRENT,\n               liqProtocolFee: EngineFlags.KEEP_CURRENT',
+    );
+    expect(test).toContain(
+      'asset: AaveV3EthereumAssets.USDC_UNDERLYING,\n               ltv: 77_00,\n               liqThreshold: 80_00,\n               liqBonus: 5_00,\n               liqProtocolFee: 10_00',
+    );
+  });
+
+  // The v3 CollateralEngine skips the ltv/lt/lb update entirely when liqThreshold == 0,
+  // so a payload configured this way leaves the collateral params untouched on-chain.
+  // The generated test must still encode the configured intent (lt = 0, collateral
+  // disabled) so it fails against such a payload instead of green-lighting a no-op.
+  it('encodes configured intent for liqThreshold 0 even though the engine ignores it', () => {
+    const ltZeroOutput = collateralsUpdates.build({
+      options: MOCK_OPTIONS,
+      market: 'AaveV3Ethereum',
+      cfg: [{asset: 'WETH', ltv: '0', liqThreshold: '0', liqBonus: '', liqProtocolFee: ''}],
+      cache: {blockNumber: 42},
+      configs: {},
+    });
+    const test = ltZeroOutput.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('ltv: 0');
+    expect(test).toContain('liqThreshold: 0');
+    expect(test).toContain('liqBonus: EngineFlags.KEEP_CURRENT');
+    expect(test).toContain('liqProtocolFee: EngineFlags.KEEP_CURRENT');
+  });
+});

--- a/generator/features/collateralsUpdates.ts
+++ b/generator/features/collateralsUpdates.ts
@@ -1,5 +1,4 @@
 import {CodeArtifact, FEATURE, FeatureModule, MarketIdentifier} from '../types';
-import {percentInput} from '../prompts';
 import {CollateralUpdate, CollateralUpdatePartial} from './types';
 import {
   assetsSelectPrompt,
@@ -33,6 +32,36 @@ export async function fetchCollateralUpdate(
 
 type CollateralUpdates = CollateralUpdate[];
 
+function renderCollateralUpdates(
+  market: MarketIdentifier,
+  cfgs: CollateralUpdates,
+  varName: string,
+) {
+  return cfgs
+    .map(
+      (cfg, ix) => `${varName}[${ix}] = IAaveV3ConfigEngine.CollateralUpdate({
+               asset: ${translateAssetToAssetLibUnderlying(cfg.asset, market)},
+               ltv: ${translateJsPercentToSol(cfg.ltv)},
+               liqThreshold: ${translateJsPercentToSol(cfg.liqThreshold)},
+               liqBonus: ${translateJsPercentToSol(cfg.liqBonus)},
+               liqProtocolFee: ${translateJsPercentToSol(cfg.liqProtocolFee)}
+             });`,
+    )
+    .join('\n');
+}
+
+function collateralUpdateOverrides(market: MarketIdentifier, cfgs: CollateralUpdates): string[] {
+  return [
+    `function _expectedCollateralChanges() internal pure override returns (IAaveV3ConfigEngine.CollateralUpdate[] memory) {
+      IAaveV3ConfigEngine.CollateralUpdate[] memory collateralUpdate;
+      collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](${cfgs.length});
+
+      ${renderCollateralUpdates(market, cfgs, 'collateralUpdate')}
+      return collateralUpdate;
+    }`,
+  ];
+}
+
 export const collateralsUpdates: FeatureModule<CollateralUpdates> = {
   value: FEATURE.COLLATERALS_UPDATE,
   description: 'CollateralsUpdates (ltv,lt,lb,liqProtocolFee,eModeCategory)',
@@ -60,21 +89,15 @@ export const collateralsUpdates: FeatureModule<CollateralUpdates> = {
             cfg.length
           });
 
-          ${cfg
-            .map(
-              (cfg, ix) => `collateralUpdate[${ix}] = IAaveV3ConfigEngine.CollateralUpdate({
-               asset: ${translateAssetToAssetLibUnderlying(cfg.asset, market)},
-               ltv: ${translateJsPercentToSol(cfg.ltv)},
-               liqThreshold: ${translateJsPercentToSol(cfg.liqThreshold)},
-               liqBonus: ${translateJsPercentToSol(cfg.liqBonus)},
-               liqProtocolFee: ${translateJsPercentToSol(cfg.liqProtocolFee)}
-             });`,
-            )
-            .join('\n')}
+          ${renderCollateralUpdates(market, cfg, 'collateralUpdate')}
 
           return collateralUpdate;
         }`,
         ],
+      },
+      test: {
+        fn: collateralUpdateOverrides(market, cfg),
+        updatedAssets: cfg.map((cfg) => translateAssetToAssetLibUnderlying(cfg.asset, market)),
       },
     };
     return response;

--- a/generator/features/freeze.spec.ts
+++ b/generator/features/freeze.spec.ts
@@ -1,0 +1,20 @@
+import {expect, describe, it} from 'vitest';
+import {freezeUpdates} from './freeze';
+import {MOCK_OPTIONS} from './mocks/configs';
+
+describe('feature: freezeUpdates', () => {
+  it('declares expected reserve config changes', () => {
+    const output = freezeUpdates.build({
+      options: MOCK_OPTIONS,
+      market: 'AaveV3Ethereum',
+      cfg: [{asset: 'DAI', shouldBeFrozen: true}],
+      cache: {blockNumber: 42},
+      configs: {},
+    });
+    const test = output.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('function _expectedFreezeChanges()');
+    expect(test).toContain('assets[0] = AaveV3EthereumAssets.DAI_UNDERLYING');
+    expect(test).toContain('frozen[0] = true');
+  });
+});

--- a/generator/features/freeze.ts
+++ b/generator/features/freeze.ts
@@ -1,10 +1,26 @@
 import {confirm} from '@inquirer/prompts';
-import {CodeArtifact, FEATURE, FeatureModule} from '../types';
+import {CodeArtifact, FEATURE, FeatureModule, MarketIdentifier} from '../types';
 import {FreezeUpdate} from './types';
 import {
   assetsSelectPrompt,
   translateAssetToAssetLibUnderlying,
 } from '../prompts/assetsSelectPrompt';
+
+function freezeUpdateOverrides(market: MarketIdentifier, cfgs: FreezeUpdate[]): string[] {
+  return [
+    `function _expectedFreezeChanges() internal pure override returns (address[] memory assets, bool[] memory frozen) {
+      assets = new address[](${cfgs.length});
+      frozen = new bool[](${cfgs.length});
+
+      ${cfgs
+        .map(
+          (cfg, ix) => `assets[${ix}] = ${translateAssetToAssetLibUnderlying(cfg.asset, market)};
+      frozen[${ix}] = ${cfg.shouldBeFrozen};`,
+        )
+        .join('\n')}
+    }`,
+  ];
+}
 
 export const freezeUpdates: FeatureModule<FreezeUpdate[]> = {
   value: FEATURE.FREEZE,
@@ -34,6 +50,10 @@ export const freezeUpdates: FeatureModule<FreezeUpdate[]> = {
               market,
             )}, ${cfg.shouldBeFrozen});`,
         ),
+      },
+      test: {
+        fn: freezeUpdateOverrides(market, cfg),
+        updatedAssets: cfg.map((cfg) => translateAssetToAssetLibUnderlying(cfg.asset, market)),
       },
     };
     return response;

--- a/generator/features/mocks/configs.ts
+++ b/generator/features/mocks/configs.ts
@@ -1,5 +1,7 @@
 import {Options} from '../../types';
 import {
+  CapsUpdate,
+  CollateralUpdate,
   EModeCategoryCreation,
   EModeCategoryUpdate,
   Listing,
@@ -90,6 +92,36 @@ export const priceFeedsUpdateConfig: PriceFeedUpdate[] = [
   {
     asset: 'DAI',
     priceFeed: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
+  },
+];
+
+export const collateralUpdates: CollateralUpdate[] = [
+  {
+    asset: 'DAI',
+    ltv: '0',
+    liqThreshold: '',
+    liqBonus: '',
+    liqProtocolFee: '',
+  },
+  {
+    asset: 'USDC',
+    ltv: '77',
+    liqThreshold: '80',
+    liqBonus: '5',
+    liqProtocolFee: '10',
+  },
+];
+
+export const capsUpdates: CapsUpdate[] = [
+  {
+    asset: 'DAI',
+    supplyCap: '1000000',
+    borrowCap: '',
+  },
+  {
+    asset: 'USDC',
+    supplyCap: '2000000',
+    borrowCap: '900000',
   },
 ];
 

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -34,6 +34,28 @@ export const testTemplate = (
     ? `defaultTest('${contractName}', address(proposal));`
     : `defaultTest('${contractName}', ${market}.POOL, address(proposal) ${isWhitelabelMarket(market) ? ', true, true' : ''});`;
 
+  const updatedAssets = Array.from(
+    new Set(
+      marketConfig.artifacts
+        .map((artifact) => artifact.test?.updatedAssets)
+        .flat()
+        .filter((asset) => asset !== undefined),
+    ),
+  );
+  const reserveConfigChangesTest =
+    testBase === 'ProtocolV3TestBase'
+      ? `
+  /**
+   * @dev checks whether reserve configurations changed or stayed unchanged as expected
+   */
+  function test_reserveConfigChanges() public {
+    address[] memory updatedAssets = new address[](${updatedAssets.length});
+    ${updatedAssets.map((asset, ix) => `updatedAssets[${ix}] = ${asset};`).join('\n    ')}
+    reserveConfigChangesTest(${market}.POOL, address(proposal), updatedAssets);
+  }
+`
+      : '';
+
   let template = `
 import 'forge-std/Test.sol';
 ${testBaseImport}
@@ -61,6 +83,7 @@ contract ${contractName}_Test is ${testBase} {
     ${defaultTestCall}
   }
 
+  ${reserveConfigChangesTest}
   ${functions}
 }`;
   return prefixWithPragma(prefixWithImports(template));

--- a/generator/types.ts
+++ b/generator/types.ts
@@ -116,6 +116,7 @@ export type CodeArtifact = {
   };
   test?: {
     fn?: string[];
+    updatedAssets?: string[];
   };
   aip?: {
     specification: string[];


### PR DESCRIPTION
## Context

This is a focused extraction from the generator work originally developed in [#1152](https://github.com/aave-dao/aave-proposals-v3/pull/1152).

PR #1152 also contains asset-listing support and generated-Solidity compilation tests. Those are intentionally excluded here to keep this PR limited to generating reserve-change assertions.

## Changes

- generate expected borrow, cap, collateral, and freeze/unfreeze reserve changes
- bump `aave-helpers` to `1165ff370b1efcd6c8c3f5340e4680cef1b96400` and sync `foundry.lock`
