### PR TITLE
feat: generate asset listing assertions

### DIFF
--- a/generator/features/__snapshots__/assetListing.spec.ts.snap
+++ b/generator/features/__snapshots__/assetListing.spec.ts.snap
@@ -174,10 +174,12 @@ pragma solidity ^0.8.0;
 
 import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
 import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 
 import 'forge-std/Test.sol';
-import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {ProtocolV3TestBase, ReserveConfig, ExpectedListing} from 'aave-helpers/src/ProtocolV3TestBase.sol';
 import {AaveV3Ethereum_Test_20231023} from './AaveV3Ethereum_Test_20231023.sol';
 
 /**
@@ -213,6 +215,34 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
     GovV3Helpers.executePayload(vm, address(proposal));
     address aTokenAddress = AaveV3Ethereum.POOL.getReserveAToken(proposal.PSP());
     assertGe(IERC20(aTokenAddress).balanceOf(address(AaveV3Ethereum.DUST_BIN)), 10 ** 18);
+  }
+
+  function _expectedListings() internal pure override returns (ExpectedListing[] memory listings) {
+    listings = new ExpectedListing[](1);
+
+    listings[0] = ExpectedListing({
+      listing: IAaveV3ConfigEngine.Listing({
+        asset: 0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5,
+        assetSymbol: 'PSP',
+        priceFeed: 0x72AFAECF99C9d9C8215fF44C77B94B99C28741e8,
+        enabledToBorrow: EngineFlags.ENABLED,
+        flashloanable: EngineFlags.ENABLED,
+        ltv: 40_00,
+        liqThreshold: 50_00,
+        liqBonus: 5_00,
+        reserveFactor: 20_00,
+        supplyCap: 10_000,
+        borrowCap: 5_000,
+        liqProtocolFee: 20_00,
+        rateStrategyParams: IAaveV3ConfigEngine.InterestRateInputData({
+          optimalUsageRatio: 80_00,
+          baseVariableBorrowRate: 0,
+          variableRateSlope1: 10_00,
+          variableRateSlope2: 100_00
+        })
+      }),
+      decimals: 18
+    });
   }
 }
 ",
@@ -372,6 +402,33 @@ address public constant PSP_PRICE_FEED = 0x72AFAECF99C9d9C8215fF44C77B94B99C2874
             assertGe(IERC20(aTokenAddress).balanceOf(address(AaveV3Ethereum.DUST_BIN)), 10 ** 18);
           }
 ",
+      "function _expectedListings() internal pure override returns (ExpectedListing[] memory listings) {
+      listings = new ExpectedListing[](1);
+
+      listings[0] = ExpectedListing({
+                 listing: IAaveV3ConfigEngine.Listing({
+                   asset: 0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5,
+  assetSymbol: "PSP",
+  priceFeed: 0x72AFAECF99C9d9C8215fF44C77B94B99C28741e8,
+  enabledToBorrow: EngineFlags.ENABLED,
+  flashloanable: EngineFlags.ENABLED,
+  ltv: 40_00,
+  liqThreshold: 50_00,
+  liqBonus: 5_00,
+  reserveFactor: 20_00,
+  supplyCap: 10_000,
+  borrowCap: 5_000,
+  liqProtocolFee: 20_00,
+  rateStrategyParams: IAaveV3ConfigEngine.InterestRateInputData({
+     optimalUsageRatio: 80_00,
+     baseVariableBorrowRate: 0,
+     variableRateSlope1: 10_00,
+     variableRateSlope2: 100_00
+  })
+                 }),
+                 decimals: 18
+               });
+    }",
     ],
   },
 }

--- a/generator/features/__snapshots__/assetListing.spec.ts.snap
+++ b/generator/features/__snapshots__/assetListing.spec.ts.snap
@@ -433,3 +433,91 @@ address public constant PSP_PRICE_FEED = 0x72AFAECF99C9d9C8215fF44C77B94B99C2874
   },
 }
 `;
+
+exports[`feature: assetListing > should return reasonable custom code 1`] = `
+{
+  "code": {
+    "constants": [
+      "// https://etherscan.io/address/0x1111111111111111111111111111111111111111
+address public constant CUSTOM_PSP = 0x1111111111111111111111111111111111111111;
+// https://etherscan.io/address/0x2222222222222222222222222222222222222222
+address public constant CUSTOM_PSP_PRICE_FEED = 0x2222222222222222222222222222222222222222;
+",
+    ],
+    "execute": [
+      "IERC20(CUSTOM_PSP).forceApprove(address(AaveV3Ethereum.POOL), 10 ** 18);
+            AaveV3Ethereum.POOL.supply(CUSTOM_PSP, 10 ** 18, AaveV3Ethereum.DUST_BIN, 0);",
+    ],
+    "fn": [
+      "function newListingsCustom() public pure override returns (IAaveV3ConfigEngine.ListingWithCustomImpl[] memory) {
+          IAaveV3ConfigEngine.ListingWithCustomImpl[] memory listings = new IAaveV3ConfigEngine.ListingWithCustomImpl[](1);
+
+          listings[0] = IAaveV3ConfigEngine.ListingWithCustomImpl(
+                IAaveV3ConfigEngine.Listing({
+                  asset: CUSTOM_PSP,
+  assetSymbol: "CUSTOM_PSP",
+  priceFeed: CUSTOM_PSP_PRICE_FEED,
+  enabledToBorrow: EngineFlags.ENABLED,
+  flashloanable: EngineFlags.ENABLED,
+  ltv: 40_00,
+  liqThreshold: 50_00,
+  liqBonus: 5_00,
+  reserveFactor: 20_00,
+  supplyCap: 10_000,
+  borrowCap: 5_000,
+  liqProtocolFee: 20_00,
+  rateStrategyParams: IAaveV3ConfigEngine.InterestRateInputData({
+     optimalUsageRatio: 80_00,
+     baseVariableBorrowRate: 0,
+     variableRateSlope1: 10_00,
+     variableRateSlope2: 100_00
+  })
+                }),
+                IAaveV3ConfigEngine.TokenImplementations({
+                  aToken: 0x3333333333333333333333333333333333333333,
+                  vToken: 0x4444444444444444444444444444444444444444
+                })
+             );
+
+          return listings;
+        }",
+    ],
+  },
+  "test": {
+    "fn": [
+      "function test_dustBinHasCUSTOM_PSPFunds() public {
+            GovV3Helpers.executePayload(vm,address(proposal));
+            address aTokenAddress = AaveV3Ethereum.POOL.getReserveAToken(proposal.CUSTOM_PSP());
+            assertGe(IERC20(aTokenAddress).balanceOf(AaveV3Ethereum.DUST_BIN), 10 ** 18);
+          }",
+      "function _expectedCustomListings() internal pure override returns (ExpectedListing[] memory listings) {
+      listings = new ExpectedListing[](1);
+
+      listings[0] = ExpectedListing({
+                 listing: IAaveV3ConfigEngine.Listing({
+                   asset: 0x1111111111111111111111111111111111111111,
+  assetSymbol: "CUSTOM_PSP",
+  priceFeed: 0x2222222222222222222222222222222222222222,
+  enabledToBorrow: EngineFlags.ENABLED,
+  flashloanable: EngineFlags.ENABLED,
+  ltv: 40_00,
+  liqThreshold: 50_00,
+  liqBonus: 5_00,
+  reserveFactor: 20_00,
+  supplyCap: 10_000,
+  borrowCap: 5_000,
+  liqProtocolFee: 20_00,
+  rateStrategyParams: IAaveV3ConfigEngine.InterestRateInputData({
+     optimalUsageRatio: 80_00,
+     baseVariableBorrowRate: 0,
+     variableRateSlope1: 10_00,
+     variableRateSlope2: 100_00
+  })
+                 }),
+                 decimals: 18
+               });
+    }",
+    ],
+  },
+}
+`;

--- a/generator/features/__snapshots__/eModesCreation.spec.ts.snap
+++ b/generator/features/__snapshots__/eModesCreation.spec.ts.snap
@@ -210,13 +210,15 @@ pragma solidity ^0.8.0;
 
 import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
 import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
 import {IERC20} from 'openzeppelin-contracts/contracts/token/ERC20/IERC20.sol';
 import {IERC20Metadata} from 'openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import {DataTypes} from 'aave-v3-origin/contracts/protocol/libraries/types/DataTypes.sol';
 import {Errors} from 'aave-v3-origin/contracts/protocol/libraries/helpers/Errors.sol';
 
 import 'forge-std/Test.sol';
-import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {ProtocolV3TestBase, ReserveConfig, ExpectedListing} from 'aave-helpers/src/ProtocolV3TestBase.sol';
 import {AaveV3Ethereum_Test_20231023} from './AaveV3Ethereum_Test_20231023.sol';
 
 /**
@@ -254,6 +256,33 @@ contract AaveV3Ethereum_Test_20231023_Test is ProtocolV3TestBase {
     assertGe(IERC20(aTokenAddress).balanceOf(address(AaveV3Ethereum.DUST_BIN)), 10 ** 18);
   }
 
+  function _expectedListings() internal pure override returns (ExpectedListing[] memory listings) {
+    listings = new ExpectedListing[](1);
+
+    listings[0] = ExpectedListing({
+      listing: IAaveV3ConfigEngine.Listing({
+        asset: 0xf7fB83435F455Bd970F2D9f943f4eECE1941b3e9,
+        assetSymbol: 'PT_sUSDe_TEST',
+        priceFeed: 0x9c823f4e19Ef68347810a9C139619273b8282b7e,
+        enabledToBorrow: EngineFlags.DISABLED,
+        flashloanable: EngineFlags.DISABLED,
+        ltv: 0,
+        liqThreshold: 0,
+        liqBonus: 0,
+        reserveFactor: 45_00,
+        supplyCap: 150_000_000,
+        borrowCap: 1,
+        liqProtocolFee: 10_00,
+        rateStrategyParams: IAaveV3ConfigEngine.InterestRateInputData({
+          optimalUsageRatio: 45_00,
+          baseVariableBorrowRate: 0,
+          variableRateSlope1: 10_00,
+          variableRateSlope2: 300_00
+        })
+      }),
+      decimals: 18
+    });
+  }
   function test_eModeConfiguration() public {
     GovV3Helpers.executePayload(vm, address(proposal));
     uint8 eMode_PT_sUSDe_TEST__Stablecoins = _findEModeCategoryId('PT_sUSDe_TEST__Stablecoins');

--- a/generator/features/assetListing.spec.ts
+++ b/generator/features/assetListing.spec.ts
@@ -17,27 +17,7 @@ describe('feature: assetListing', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('declares expected reserve config changes for new listings', () => {
-    const output = assetListing.build({
-      options: MOCK_OPTIONS,
-      market: 'AaveV3Ethereum',
-      cfg: assetListingConfig,
-      cache: {blockNumber: 42},
-      configs: {},
-    });
-    const test = output.test?.fn?.join('\n') ?? '';
-
-    expect(test).toContain('function _expectedListings()');
-    expect(test).toContain('ExpectedListing[] memory listings');
-    expect(test).toContain('listing: IAaveV3ConfigEngine.Listing');
-    expect(test).toContain('asset: 0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5');
-    expect(test).toContain('assetSymbol: "PSP"');
-    expect(test).toContain('decimals: 18');
-    expect(test).toContain('supplyCap: 10_000');
-    expect(test).toContain('borrowCap: 5_000');
-  });
-
-  it('declares expected reserve config changes for custom listings', () => {
+  it('should return reasonable custom code', () => {
     const output = assetListingCustom.build({
       options: MOCK_OPTIONS,
       market: 'AaveV3Ethereum',
@@ -45,17 +25,7 @@ describe('feature: assetListing', () => {
       cache: {blockNumber: 42},
       configs: {},
     });
-    const code = output.code?.fn?.join('\n') ?? '';
-    const test = output.test?.fn?.join('\n') ?? '';
-
-    expect(code).toContain('IAaveV3ConfigEngine.ListingWithCustomImpl(');
-    expect(code).toContain('IAaveV3ConfigEngine.TokenImplementations({');
-    expect(code).not.toContain('sToken:');
-    expect(test).toContain('function _expectedCustomListings()');
-    expect(test).toContain('ExpectedListing[] memory listings');
-    expect(test).toContain('asset: 0x1111111111111111111111111111111111111111');
-    expect(test).toContain('priceFeed: 0x2222222222222222222222222222222222222222');
-    expect(test).toContain('assetSymbol: "CUSTOM_PSP"');
+    expect(output).toMatchSnapshot();
   });
 
   it('should properly generate files', async () => {

--- a/generator/features/assetListing.spec.ts
+++ b/generator/features/assetListing.spec.ts
@@ -1,7 +1,7 @@
 // sum.test.js
 import {expect, describe, it} from 'vitest';
-import {assetListing} from './assetListing';
-import {MOCK_OPTIONS, assetListingConfig} from './mocks/configs';
+import {assetListing, assetListingCustom} from './assetListing';
+import {MOCK_OPTIONS, assetListingConfig, assetListingCustomConfig} from './mocks/configs';
 import {generateFiles} from '../generator';
 import {FEATURE, MarketConfigs} from '../types';
 
@@ -15,6 +15,47 @@ describe('feature: assetListing', () => {
       configs: {},
     });
     expect(output).toMatchSnapshot();
+  });
+
+  it('declares expected reserve config changes for new listings', () => {
+    const output = assetListing.build({
+      options: MOCK_OPTIONS,
+      market: 'AaveV3Ethereum',
+      cfg: assetListingConfig,
+      cache: {blockNumber: 42},
+      configs: {},
+    });
+    const test = output.test?.fn?.join('\n') ?? '';
+
+    expect(test).toContain('function _expectedListings()');
+    expect(test).toContain('ExpectedListing[] memory listings');
+    expect(test).toContain('listing: IAaveV3ConfigEngine.Listing');
+    expect(test).toContain('asset: 0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5');
+    expect(test).toContain('assetSymbol: "PSP"');
+    expect(test).toContain('decimals: 18');
+    expect(test).toContain('supplyCap: 10_000');
+    expect(test).toContain('borrowCap: 5_000');
+  });
+
+  it('declares expected reserve config changes for custom listings', () => {
+    const output = assetListingCustom.build({
+      options: MOCK_OPTIONS,
+      market: 'AaveV3Ethereum',
+      cfg: assetListingCustomConfig,
+      cache: {blockNumber: 42},
+      configs: {},
+    });
+    const code = output.code?.fn?.join('\n') ?? '';
+    const test = output.test?.fn?.join('\n') ?? '';
+
+    expect(code).toContain('IAaveV3ConfigEngine.ListingWithCustomImpl(');
+    expect(code).toContain('IAaveV3ConfigEngine.TokenImplementations({');
+    expect(code).not.toContain('sToken:');
+    expect(test).toContain('function _expectedCustomListings()');
+    expect(test).toContain('ExpectedListing[] memory listings');
+    expect(test).toContain('asset: 0x1111111111111111111111111111111111111111');
+    expect(test).toContain('priceFeed: 0x2222222222222222222222222222222222222222');
+    expect(test).toContain('assetSymbol: "CUSTOM_PSP"');
   });
 
   it('should properly generate files', async () => {

--- a/generator/features/assetListing.ts
+++ b/generator/features/assetListing.ts
@@ -59,14 +59,19 @@ async function fetchCustomImpl(): Promise<TokenImplementations> {
   return {
     aToken: await addressPrompt({message: 'aToken implementation', required: true}),
     vToken: await addressPrompt({message: 'vToken implementation', required: true}),
-    sToken: await addressPrompt({message: 'sToken implementation', required: true}),
   };
 }
 
-function generateAssetListingSol(cfg: Listing) {
-  return `asset: ${cfg.assetSymbol},
+// Relax address fields because rendered Solidity may use variable names instead of literal addresses.
+type RenderableListing = Omit<Listing, 'asset' | 'priceFeed'> & {
+  asset: string;
+  priceFeed: string;
+};
+
+function renderListingSol(cfg: RenderableListing) {
+  return `asset: ${cfg.asset},
   assetSymbol: "${cfg.assetSymbol}",
-  priceFeed: ${cfg.assetSymbol}_PRICE_FEED,
+  priceFeed: ${cfg.priceFeed},
   enabledToBorrow: ${translateJsBoolToSol(cfg.enabledToBorrow)},
   flashloanable: ${translateJsBoolToSol(cfg.flashloanable)},
   ltv: ${translateJsPercentToSol(cfg.ltv)},
@@ -86,6 +91,37 @@ function generateAssetListingSol(cfg: Listing) {
   })`;
 }
 
+function generateAssetListingSol(cfg: Listing) {
+  return renderListingSol({
+    ...cfg,
+    asset: cfg.assetSymbol,
+    priceFeed: `${cfg.assetSymbol}_PRICE_FEED`,
+  });
+}
+
+function listingOverrides(cfgs: Listing[], fnName: string): string[] {
+  return [
+    `function ${fnName}() internal pure override returns (ExpectedListing[] memory listings) {
+      listings = new ExpectedListing[](${cfgs.length});
+
+      ${cfgs
+        .map(
+          (cfg, ix) => `listings[${ix}] = ExpectedListing({
+                 listing: IAaveV3ConfigEngine.Listing({
+                   ${renderListingSol({
+                     ...cfg,
+                     asset: translateJsAddressToSol(cfg.asset),
+                     priceFeed: translateJsAddressToSol(cfg.priceFeed),
+                   })}
+                 }),
+                 decimals: ${cfg.decimals}
+               });`,
+        )
+        .join('\n')}
+    }`,
+  ];
+}
+
 export const assetListing: FeatureModule<Listing[]> = {
   value: FEATURE.ASSET_LISTING,
   description: 'newListings (listing a new asset)',
@@ -100,6 +136,22 @@ export const assetListing: FeatureModule<Listing[]> = {
     return response;
   },
   build({market, cfg}) {
+    const listingTests = cfg.map((cfg) => {
+      let listingTest = `function test_dustBinHas${cfg.assetSymbol}Funds() public {
+            ${testExecuteProposal(market)}
+            address aTokenAddress = ${market}.POOL.getReserveAToken(proposal.${cfg.assetSymbol}());
+            assertGe(IERC20(aTokenAddress).balanceOf(address(${market}.DUST_BIN)), 10 ** ${cfg.decimals});
+          }\n`;
+      if (isAddress(cfg.admin)) {
+        listingTest += `\nfunction test_${cfg.assetSymbol}Admin() public {
+	      ${testExecuteProposal(market)}
+              address a${cfg.assetSymbol} = ${market}.POOL.getReserveAToken(proposal.${cfg.assetSymbol}());
+	      assertEq(IEmissionManager(${market}.EMISSION_MANAGER).getEmissionAdmin(proposal.${cfg.assetSymbol}()), proposal.${cfg.assetSymbol}_LM_ADMIN());
+	      assertEq(IEmissionManager(${market}.EMISSION_MANAGER).getEmissionAdmin(a${cfg.assetSymbol}), proposal.${cfg.assetSymbol}_LM_ADMIN());
+	    }\n`;
+      }
+      return listingTest;
+    });
     const response: CodeArtifact = {
       code: {
         constants: cfg.map((cfg) => {
@@ -152,22 +204,7 @@ export const assetListing: FeatureModule<Listing[]> = {
         ],
       },
       test: {
-        fn: cfg.map((cfg) => {
-          let listingTest = `function test_dustBinHas${cfg.assetSymbol}Funds() public {
-            ${testExecuteProposal(market)}
-            address aTokenAddress = ${market}.POOL.getReserveAToken(proposal.${cfg.assetSymbol}());
-            assertGe(IERC20(aTokenAddress).balanceOf(address(${market}.DUST_BIN)), 10 ** ${cfg.decimals});
-          }\n`;
-          if (isAddress(cfg.admin)) {
-            listingTest += `\nfunction test_${cfg.assetSymbol}Admin() public {
-	      ${testExecuteProposal(market)}
-              address a${cfg.assetSymbol} = ${market}.POOL.getReserveAToken(proposal.${cfg.assetSymbol}());
-	      assertEq(IEmissionManager(${market}.EMISSION_MANAGER).getEmissionAdmin(proposal.${cfg.assetSymbol}()), proposal.${cfg.assetSymbol}_LM_ADMIN());
-	      assertEq(IEmissionManager(${market}.EMISSION_MANAGER).getEmissionAdmin(a${cfg.assetSymbol}), proposal.${cfg.assetSymbol}_LM_ADMIN());
-	    }\n`;
-          }
-          return listingTest;
-        }),
+        fn: [...listingTests, ...listingOverrides(cfg, '_expectedListings')],
       },
       aip: {
         specification: cfg.map((cfg) => {
@@ -229,6 +266,13 @@ export const assetListingCustom: FeatureModule<ListingWithCustomImpl[]> = {
     return response;
   },
   build({market, cfg}) {
+    const listingTests = cfg.map(
+      (cfg) => `function test_dustBinHas${cfg.base.assetSymbol}Funds() public {
+            ${testExecuteProposal(market)}
+            address aTokenAddress = ${market}.POOL.getReserveAToken(proposal.${cfg.base.assetSymbol}());
+            assertGe(IERC20(aTokenAddress).balanceOf(${market}.DUST_BIN), 10 ** ${cfg.base.decimals});
+          }`,
+    );
     const response: CodeArtifact = {
       code: {
         constants: cfg.map((cfg) => {
@@ -256,12 +300,11 @@ export const assetListingCustom: FeatureModule<ListingWithCustomImpl[]> = {
             .map(
               (cfg, ix) => `listings[${ix}] = IAaveV3ConfigEngine.ListingWithCustomImpl(
                 IAaveV3ConfigEngine.Listing({
-                  ${generateAssetListingSol(cfg.base)},
-                  IAaveV3ConfigEngine.TokenImplementations({
-                    aToken: ${translateJsAddressToSol(cfg.implementations.aToken)},
-                    vToken: ${translateJsAddressToSol(cfg.implementations.vToken)},
-                    sToken: ${translateJsAddressToSol(cfg.implementations.sToken)}
-                  })
+                  ${generateAssetListingSol(cfg.base)}
+                }),
+                IAaveV3ConfigEngine.TokenImplementations({
+                  aToken: ${translateJsAddressToSol(cfg.implementations.aToken)},
+                  vToken: ${translateJsAddressToSol(cfg.implementations.vToken)}
                 })
              );`,
             )
@@ -272,13 +315,13 @@ export const assetListingCustom: FeatureModule<ListingWithCustomImpl[]> = {
         ],
       },
       test: {
-        fn: cfg.map(
-          (cfg) => `function test_dustBinHas${cfg.base.assetSymbol}Funds() public {
-            ${testExecuteProposal(market)}
-            address aTokenAddress = ${market}.POOL.getReserveAToken(proposal.${cfg.base.assetSymbol}());
-            assertGte(IERC20(aTokenAddress).balanceOf(${market}.DUST_BIN), 10 ** ${cfg.base.decimals});
-          }`,
-        ),
+        fn: [
+          ...listingTests,
+          ...listingOverrides(
+            cfg.map((cfg) => cfg.base),
+            '_expectedCustomListings',
+          ),
+        ],
       },
     };
     return response;

--- a/generator/features/mocks/configs.ts
+++ b/generator/features/mocks/configs.ts
@@ -5,6 +5,7 @@ import {
   EModeCategoryCreation,
   EModeCategoryUpdate,
   Listing,
+  ListingWithCustomImpl,
   PriceFeedUpdate,
   RateStrategyUpdate,
 } from '../types';
@@ -46,6 +47,21 @@ export const assetListingConfig: Listing[] = [
     },
     eModeCategory: 'AaveV3EthereumEModes.NONE',
     asset: '0xcAfE001067cDEF266AfB7Eb5A286dCFD277f3dE5',
+  },
+];
+
+export const assetListingCustomConfig: ListingWithCustomImpl[] = [
+  {
+    base: {
+      ...assetListingConfig[0],
+      assetSymbol: 'CUSTOM_PSP',
+      asset: '0x1111111111111111111111111111111111111111',
+      priceFeed: '0x2222222222222222222222222222222222222222',
+    },
+    implementations: {
+      aToken: '0x3333333333333333333333333333333333333333',
+      vToken: '0x4444444444444444444444444444444444444444',
+    },
   },
 ];
 

--- a/generator/features/types.ts
+++ b/generator/features/types.ts
@@ -11,7 +11,6 @@ export interface AssetSelector {
 export interface TokenImplementations {
   aToken: Hex;
   vToken: Hex;
-  sToken: Hex;
 }
 
 export interface CapsUpdatePartial {

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -17,6 +17,7 @@ export const testTemplate = (
 ) => {
   const folderName = generateFolderName(options);
   const chain = getMarketChain(market);
+  const isZkSync = chain === 'ZkSync';
   const contractName = generateContractName(options, market);
   const {v4, testBase} = getTestBase(market);
 
@@ -26,14 +27,15 @@ export const testTemplate = (
     .filter((f) => f !== undefined)
     .join('\n');
 
-  const expectedListingImport =
-    testBase === 'ProtocolV3TestBase' && functions.includes('ExpectedListing')
-      ? ', ExpectedListing'
-      : '';
+  const testBaseImports = [testBase, 'ReserveConfig'];
+  if (testBase === 'ProtocolV3TestBase' && functions.includes('ExpectedListing')) {
+    testBaseImports.push('ExpectedListing');
+  }
+  const testBasePath = isZkSync ? 'zksync/src/' : 'src/';
 
   const testBaseImport = v4
     ? `import {${testBase}} from 'aave-helpers/src/v4-protocol-test/${testBase}.sol';`
-    : `import {${testBase}, ReserveConfig${expectedListingImport}} from 'aave-helpers/${chain === 'ZkSync' ? 'zksync/src/' : 'src/'}${testBase}.sol';`;
+    : `import {${testBaseImports.join(', ')}} from 'aave-helpers/${testBasePath}${testBase}.sol';`;
 
   const defaultTestCall = v4
     ? `defaultTest('${contractName}', address(proposal));`

--- a/generator/templates/test.template.ts
+++ b/generator/templates/test.template.ts
@@ -26,9 +26,14 @@ export const testTemplate = (
     .filter((f) => f !== undefined)
     .join('\n');
 
+  const expectedListingImport =
+    testBase === 'ProtocolV3TestBase' && functions.includes('ExpectedListing')
+      ? ', ExpectedListing'
+      : '';
+
   const testBaseImport = v4
     ? `import {${testBase}} from 'aave-helpers/src/v4-protocol-test/${testBase}.sol';`
-    : `import {${testBase}, ReserveConfig} from 'aave-helpers/${chain === 'ZkSync' ? 'zksync/src/' : 'src/'}${testBase}.sol';`;
+    : `import {${testBase}, ReserveConfig${expectedListingImport}} from 'aave-helpers/${chain === 'ZkSync' ? 'zksync/src/' : 'src/'}${testBase}.sol';`;
 
   const defaultTestCall = v4
     ? `defaultTest('${contractName}', address(proposal));`


### PR DESCRIPTION
## Context

This is the focused extraction from the generator work originally developed in [#1152](https://github.com/aave-dao/aave-proposals-v3/pull/1152).

PR #1152 also contains generated-Solidity compilation infrastructure and other generator coverage. Those are intentionally excluded here to keep this PR limited to asset-listing assertions.

## Changes

- generate expected listing assertions for standard and custom asset listings
- import `ExpectedListing` into generated proposal tests when required
- align custom listing generation with the current config-engine token implementation shape
