### PR TITLE
test: compile generated Solidity in generator tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,16 @@ jobs:
           exit 1
 
   test-js:
-    uses: aave-dao/github-workflows/.github/workflows/test-node.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: aave-dao/github-workflows/.github/actions/setup-node@main
+
+      - name: Run Foundry setup
+        uses: aave-dao/github-workflows/.github/actions/foundry-setup@main
+
+      - name: Run tests
+        run: pnpm test

--- a/generator/features/assetListing.spec.ts
+++ b/generator/features/assetListing.spec.ts
@@ -4,6 +4,7 @@ import {assetListing, assetListingCustom} from './assetListing';
 import {MOCK_OPTIONS, assetListingConfig, assetListingCustomConfig} from './mocks/configs';
 import {generateFiles} from '../generator';
 import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: assetListing', () => {
   it('should return reasonable code', () => {
@@ -48,4 +49,36 @@ describe('feature: assetListing', () => {
     const files = await generateFiles(MOCK_OPTIONS, marketConfigs);
     expect(files).toMatchSnapshot();
   });
+
+  it('generates compilable files for every listing variant', async () => {
+    const configs = {
+      [FEATURE.ASSET_LISTING]: assetListingConfig,
+      [FEATURE.ASSET_LISTING_CUSTOM]: assetListingCustomConfig,
+    };
+    const marketConfigs: MarketConfigs = {
+      [MOCK_OPTIONS.markets[0]]: {
+        market: MOCK_OPTIONS.markets[0],
+        artifacts: [
+          assetListing.build({
+            options: MOCK_OPTIONS,
+            market: 'AaveV3Ethereum',
+            cfg: assetListingConfig,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+          assetListingCustom.build({
+            options: MOCK_OPTIONS,
+            market: 'AaveV3Ethereum',
+            cfg: assetListingCustomConfig,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+        ],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 });

--- a/generator/features/borrowsUpdates.spec.ts
+++ b/generator/features/borrowsUpdates.spec.ts
@@ -1,6 +1,10 @@
 import {expect, describe, it} from 'vitest';
 import {borrowsUpdates} from './borrowsUpdates';
 import {MOCK_OPTIONS} from './mocks/configs';
+import {BorrowUpdate} from './types';
+import {generateFiles} from '../generator';
+import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: borrowsUpdates', () => {
   it('declares expected reserve config changes', () => {
@@ -26,4 +30,34 @@ describe('feature: borrowsUpdates', () => {
     expect(test).toContain('flashloanable: EngineFlags.KEEP_CURRENT');
     expect(test).toContain('reserveFactor: 25_00');
   });
+
+  it('generates compilable Solidity', async () => {
+    const cfg: BorrowUpdate[] = [
+      {
+        asset: 'DAI',
+        enabledToBorrow: 'DISABLED',
+        flashloanable: 'KEEP_CURRENT',
+        reserveFactor: '25',
+      },
+    ];
+    const configs = {[FEATURE.BORROWS_UPDATE]: cfg};
+    const marketConfigs: MarketConfigs = {
+      AaveV3Ethereum: {
+        market: 'AaveV3Ethereum',
+        artifacts: [
+          borrowsUpdates.build({
+            options: MOCK_OPTIONS,
+            market: 'AaveV3Ethereum',
+            cfg,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+        ],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 });

--- a/generator/features/capsUpdates.spec.ts
+++ b/generator/features/capsUpdates.spec.ts
@@ -1,6 +1,9 @@
 import {expect, describe, it} from 'vitest';
 import {capsUpdates} from './capsUpdates';
 import {MOCK_OPTIONS, capsUpdates as capsUpdatesConfig} from './mocks/configs';
+import {generateFiles} from '../generator';
+import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: capsUpdates', () => {
   const output = capsUpdates.build({
@@ -14,6 +17,20 @@ describe('feature: capsUpdates', () => {
   it('should return reasonable code', () => {
     expect(output).toMatchSnapshot();
   });
+
+  it('generates compilable Solidity', async () => {
+    const configs = {[FEATURE.CAPS_UPDATE]: capsUpdatesConfig};
+    const marketConfigs: MarketConfigs = {
+      AaveV3Ethereum: {
+        market: 'AaveV3Ethereum',
+        artifacts: [output],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 
   it('declares updated assets for reserve config validation', () => {
     expect(output.test?.updatedAssets).toEqual([

--- a/generator/features/collateralsUpdates.spec.ts
+++ b/generator/features/collateralsUpdates.spec.ts
@@ -1,6 +1,9 @@
 import {expect, describe, it} from 'vitest';
 import {collateralsUpdates} from './collateralsUpdates';
 import {MOCK_OPTIONS, collateralUpdates as collateralUpdatesConfig} from './mocks/configs';
+import {generateFiles} from '../generator';
+import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: collateralsUpdates', () => {
   const output = collateralsUpdates.build({
@@ -14,6 +17,20 @@ describe('feature: collateralsUpdates', () => {
   it('should return reasonable code', () => {
     expect(output).toMatchSnapshot();
   });
+
+  it('generates compilable Solidity', async () => {
+    const configs = {[FEATURE.COLLATERALS_UPDATE]: collateralUpdatesConfig};
+    const marketConfigs: MarketConfigs = {
+      AaveV3Ethereum: {
+        market: 'AaveV3Ethereum',
+        artifacts: [output],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 
   it('encodes set fields as values and empty fields as KEEP_CURRENT on the payload struct', () => {
     const code = (output.code?.fn?.join('\n') ?? '').replace(/\s+/g, ' ');

--- a/generator/features/eModesCreation.spec.ts
+++ b/generator/features/eModesCreation.spec.ts
@@ -5,6 +5,7 @@ import {MOCK_OPTIONS, emodeCreations, ptListingConfig} from './mocks/configs';
 import {toSolidityIdentifier} from '../common';
 import {generateFiles} from '../generator';
 import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 const configs = {
   [FEATURE.ASSET_LISTING]: ptListingConfig,
@@ -58,6 +59,10 @@ describe('feature: eModesCreation', () => {
     const files = await generateFiles(MOCK_OPTIONS, buildMarketConfigs());
     expect(files).toMatchSnapshot();
   });
+
+  it('generates compilable Solidity', async () => {
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, buildMarketConfigs()));
+  }, 60_000);
 
   it('generates the expected e-mode test coverage', async () => {
     const files = await generateFiles(MOCK_OPTIONS, buildMarketConfigs());

--- a/generator/features/eModesUpdates.spec.ts
+++ b/generator/features/eModesUpdates.spec.ts
@@ -1,6 +1,10 @@
 import {expect, describe, it} from 'vitest';
 import {eModeUpdates} from './eModesUpdates';
 import {MOCK_OPTIONS, emodeUpdates} from './mocks/configs';
+import {generateFiles} from '../generator';
+import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
+import {EModeCategoryUpdate} from './types';
 
 describe('feature: eModesUpdates', () => {
   const output = eModeUpdates.build({
@@ -16,6 +20,34 @@ describe('feature: eModesUpdates', () => {
     expect(fns).toContain('isolated: EngineFlags.ENABLED');
     expect(fns).toContain('isolated: EngineFlags.KEEP_CURRENT');
   });
+
+  it('generates compilable Solidity', async () => {
+    const cfg: EModeCategoryUpdate[] = [
+      {
+        ...emodeUpdates[1],
+        eModeCategory: 'AaveV3EthereumEModes.WETH_wstETH_cbETH_rETH_weETH_osETH_ETHx__WETH',
+      },
+    ];
+    const configs = {[FEATURE.EMODES_UPDATES]: cfg};
+    const marketConfigs: MarketConfigs = {
+      AaveV3Ethereum: {
+        market: 'AaveV3Ethereum',
+        artifacts: [
+          eModeUpdates.build({
+            options: MOCK_OPTIONS,
+            market: 'AaveV3Ethereum',
+            cfg,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+        ],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 
   it('asserts set fields to their value and KEEP_CURRENT fields to the pre-payload value', () => {
     const test = output.test?.fn?.join('\n') ?? '';

--- a/generator/features/freeze.spec.ts
+++ b/generator/features/freeze.spec.ts
@@ -1,6 +1,10 @@
 import {expect, describe, it} from 'vitest';
 import {freezeUpdates} from './freeze';
 import {MOCK_OPTIONS} from './mocks/configs';
+import {FreezeUpdate} from './types';
+import {generateFiles} from '../generator';
+import {FEATURE, MarketConfigs} from '../types';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: freezeUpdates', () => {
   it('declares expected reserve config changes', () => {
@@ -17,4 +21,27 @@ describe('feature: freezeUpdates', () => {
     expect(test).toContain('assets[0] = AaveV3EthereumAssets.DAI_UNDERLYING');
     expect(test).toContain('frozen[0] = true');
   });
+
+  it('generates compilable Solidity', async () => {
+    const cfg: FreezeUpdate[] = [{asset: 'DAI', shouldBeFrozen: true}];
+    const configs = {[FEATURE.FREEZE]: cfg};
+    const marketConfigs: MarketConfigs = {
+      AaveV3Ethereum: {
+        market: 'AaveV3Ethereum',
+        artifacts: [
+          freezeUpdates.build({
+            options: MOCK_OPTIONS,
+            market: 'AaveV3Ethereum',
+            cfg,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+        ],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 });

--- a/generator/features/priceFeedsUpdate.spec.ts
+++ b/generator/features/priceFeedsUpdate.spec.ts
@@ -4,6 +4,7 @@ import {MOCK_OPTIONS, priceFeedsUpdateConfig} from './mocks/configs';
 import {generateFiles} from '../generator';
 import {FEATURE, MarketConfigs} from '../types';
 import {priceFeedsUpdates} from './priceFeedsUpdates';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: priceFeedsUpdates', () => {
   it('should return reasonable code', () => {
@@ -37,4 +38,26 @@ describe('feature: priceFeedsUpdates', () => {
     const files = await generateFiles(MOCK_OPTIONS, marketConfigs);
     expect(files).toMatchSnapshot();
   });
+
+  it('generates compilable Solidity', async () => {
+    const configs = {[FEATURE.PRICE_FEEDS_UPDATE]: priceFeedsUpdateConfig};
+    const marketConfigs: MarketConfigs = {
+      [MOCK_OPTIONS.markets[0]]: {
+        market: MOCK_OPTIONS.markets[0],
+        artifacts: [
+          priceFeedsUpdates.build({
+            options: MOCK_OPTIONS,
+            market: 'AaveV3Ethereum',
+            cfg: priceFeedsUpdateConfig,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+        ],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(MOCK_OPTIONS, marketConfigs));
+  }, 60_000);
 });

--- a/generator/features/rateUpdates.spec.ts
+++ b/generator/features/rateUpdates.spec.ts
@@ -4,6 +4,7 @@ import {MOCK_OPTIONS, rateUpdateV2} from './mocks/configs';
 import {generateFiles} from '../generator';
 import {FEATURE, MarketConfigs} from '../types';
 import {rateUpdatesV2} from './rateUpdates';
+import {compileGeneratedFiles} from '../utils/compileGeneratedFiles';
 
 describe('feature: rateUpdatesV2', () => {
   it('should return reasonable code', () => {
@@ -39,4 +40,26 @@ describe('feature: rateUpdatesV2', () => {
     );
     expect(files).toMatchSnapshot();
   });
+
+  it('generates compilable Solidity', async () => {
+    const options = {...MOCK_OPTIONS, markets: ['AaveV2EthereumAMM' as const]};
+    const configs = {[FEATURE.RATE_UPDATE_V2]: rateUpdateV2};
+    const marketConfigs: MarketConfigs = {
+      AaveV2EthereumAMM: {
+        artifacts: [
+          rateUpdatesV2.build({
+            options,
+            market: 'AaveV2EthereumAMM',
+            cfg: rateUpdateV2,
+            cache: {blockNumber: 42},
+            configs,
+          }),
+        ],
+        configs,
+        cache: {blockNumber: 42},
+      },
+    };
+
+    compileGeneratedFiles(await generateFiles(options, marketConfigs));
+  }, 60_000);
 });

--- a/generator/utils/compileGeneratedFiles.ts
+++ b/generator/utils/compileGeneratedFiles.ts
@@ -1,0 +1,41 @@
+import {execFileSync} from 'node:child_process';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import type {Files} from '../types';
+
+export function compileGeneratedFiles(files: Files) {
+  const tempDir = mkdtempSync(path.join(process.cwd(), '.generator-compile-'));
+  const sources: string[] = [];
+
+  try {
+    const fixtureDir = path.join(tempDir, 'src');
+    mkdirSync(fixtureDir);
+
+    files.payloads.forEach(({payload, test, contractName}) => {
+      const payloadPath = path.join(fixtureDir, `${contractName}.sol`);
+      const testPath = path.join(fixtureDir, `${contractName}.t.sol`);
+      writeFileSync(payloadPath, payload);
+      writeFileSync(testPath, test);
+      sources.push(testPath);
+    });
+
+    const scriptPath = path.join(fixtureDir, 'Generated.s.sol');
+    writeFileSync(scriptPath, files.scripts.defaultScript);
+    sources.push(scriptPath);
+
+    execFileSync('forge', ['build', ...sources], {
+      cwd: process.cwd(),
+      env: {...process.env, FOUNDRY_PROFILE: 'test'},
+      stdio: 'pipe',
+      timeout: 55_000,
+    });
+  } catch (error) {
+    const forgeError = error as Error & {stdout?: Buffer; stderr?: Buffer};
+    const output = [forgeError.stdout?.toString(), forgeError.stderr?.toString()]
+      .filter(Boolean)
+      .join('\n');
+    throw new Error(`Generated Solidity failed to compile:\n${output}`, {cause: error});
+  } finally {
+    rmSync(tempDir, {recursive: true, force: true});
+  }
+}


### PR DESCRIPTION
- add a shared helper that compiles generated payloads, tests, and deployment scripts with Forge
- provision Foundry in the JavaScript CI job
- add tests to make sure that generated solidity code compiles to prevent discovering about failures when the code is compiled

This isolates the remaining generated-bytecode coverage from #1152