### PR TITLE
docs: add Aave proposal writing skill

### DIFF
--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -12,7 +12,11 @@ Help the user question the implementation and verify that it matches the proposa
 - Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
 - Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
-- For multichain scope, start from the set used by the Risk Stewards AIP: Ethereum (Core, Lido, and EtherFi), Polygon, Avalanche, Arbitrum, Optimism, Base, Gnosis, BNB Chain, Scroll, Linea, Sonic, Celo, Mantle, Plasma, MegaETH, Monad, and X Layer. Check whether it has changed, list relevant deprecated, legacy, or partial deployments separately with their consequences, then ask which chains to include.
+- If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.
+- For multichain scope, start from the Risk Stewards reference split and verify its current status:
+  - Active: Ethereum (Core and Lido), Polygon, Avalanche, Arbitrum, Optimism, Base, Gnosis, BNB Chain, Scroll, Linea, Sonic, Celo, Mantle, Plasma, MegaETH, Monad, and X Layer.
+  - Deprecated: Ethereum EtherFi, Metis, Soneium, and zkSync.
+    Explain the consequences and ask which deployments to include.
 
 ## Choose execution shape
 

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -1,79 +1,12 @@
 ---
 name: write-aave-proposals
-description: Use automatically when creating, implementing, testing, documenting, or reviewing an Aave governance proposal. Do not use for work on the proposal generator or its features. Surface specification, execution, interface, testing, documentation, and multichain-dispatch knowledge while leaving material choices to the writer.
+description: Use automatically when creating, implementing, testing, documenting, or reviewing an Aave governance proposal. Do not use for work on the proposal generator or its features. Route proposal work to the relevant specialist guidance.
 ---
 
 # Write Aave Proposals
 
-Help the user question the implementation and verify that it matches the proposal's actual intent; do not put the agent on autopilot or impose opinionated choices.
+Read [proposal authoring](references/proposal-authoring.md) for every proposal, then read only the specialist that matches the proposal:
 
-## Reconcile scope
+- For a new asset listing, read [asset listings](references/asset-listing.md).
 
-- Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
-- Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
-- Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
-- If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.
-- For multichain scope, use this baseline and verify its current status:
-  - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
-  - V3 deprecated (legacy): Sonic, Scroll, zkSync, Metis, Soneium, Aptos, and Ethereum EtherFi.
-  - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
-- Treat any V3 deployment absent from the active list as deprecated. Deprecated status is context, not a prohibition: inform the user and let them decide whether to include the deployment.
-
-## Bootstrap and choose custom execution shape
-
-Always bootstrap the proposal with the repository generator. If it has no premade setup for the required action, preserve the generated structure and build the custom implementation from it. For custom proposals, choose how to register multiple actions:
-
-- One `createPayload` call with multiple actions creates one payload ID. Actions execute sequentially and atomically: one revert rolls back the whole payload. Prefer this for dependent actions.
-
-```solidity
-IPayloadsControllerCore.ExecutionAction[] memory actions =
-  new IPayloadsControllerCore.ExecutionAction[](2);
-actions[0] = GovV3Helpers.buildAction(payloadA);
-actions[1] = GovV3Helpers.buildAction(payloadB);
-GovV3Helpers.createPayload(actions);
-```
-
-- Separate `createPayload` calls create separate payload IDs. Their executions are failure-isolated and have no ordering guarantee, even when included in one governance proposal. Prefer this for independent actions.
-
-```solidity
-IPayloadsControllerCore.ExecutionAction[] memory actions =
-  new IPayloadsControllerCore.ExecutionAction[](1);
-actions[0] = GovV3Helpers.buildAction(payloadA);
-GovV3Helpers.createPayload(actions);
-actions[0] = GovV3Helpers.buildAction(payloadB);
-GovV3Helpers.createPayload(actions);
-```
-
-- Recommend based on dependency and failure isolation, then ask when no choice was given.
-
-## Reuse contract surfaces
-
-- Address-book interfaces take priority; update the canonical interface when a method is missing instead of shadowing it locally.
-- For Aave-infrastructure contracts, add missing entries to `aave-address-book`, then propagate the revision through `aave-helpers` before using it here.
-- If the address book has no interface, a minimal local interface containing only required methods is fine.
-- Do not add a dependency solely to obtain an interface.
-- Prefer typed entries and runtime getters over recasting and hardcoded role hashes.
-- Before deploying a contract in `execute`, surface whether it is one-off or likely reusable. Keep one-offs local; recommend predeploying, verifying, and registering recurring components.
-
-## Keep implementation focused
-
-- Keep NatSpec and inline comments to intent and non-obvious invariants.
-
-## Test behavior
-
-- For each material change, propose an exact pre-state assertion, one execution, and a post-state assertion.
-- When rewriting a configuration, identify untouched fields at risk and test selected unchanged fields.
-- Inspect generated diffs and events; flag missing instrumentation instead of treating an absent diff as proof of no change.
-
-## Write Markdown
-
-- Use the current generator skeleton and References format; regenerate instead of handcrafting the layout.
-- Fetch the Discourse topic through its `.json` URL, save the post content, and mechanically diff it with the Markdown after normalizing only generator-imposed structure and explicit Disclaimer removal. Content differences are not acceptable.
-- Keep generated repository links on `main` before merge so the IPFS workflow can pin the final commit.
-- Diff against both the generator skeleton and saved forum content, accounting for every difference.
-
-## Validate large cross-chain dispatches
-
-- Simulate the complete Ethereum `executeProposal` from cold state using real Governance, CrossChainController, and configured adapters rather than per-payload mocks.
-- Report gas against current constraints, `PayloadSent` count, adapter attempts, and successful destinations, distinguishing attempts from chains.
-- If results or margin are concerning, present splitting options and ask before changing the execution shape.
+If no specialist matches, use only the shared proposal-authoring guidance.

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -19,7 +19,9 @@ Help the user question the implementation and verify that it matches the proposa
   - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
 - Treat any V3 deployment absent from the active list as deprecated. Explain the consequences and ask which deployments to include.
 
-## Choose execution shape
+## Bootstrap and choose custom execution shape
+
+Always bootstrap the proposal with the repository generator. If it has no premade setup for the required action, preserve the generated structure and build the custom implementation from it. For custom proposals, choose how to register multiple actions:
 
 - One `createPayload` call with multiple actions creates one payload ID. Actions execute sequentially and atomically: one revert rolls back the whole payload. Prefer this for dependent actions.
 

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -14,8 +14,8 @@ Help the user question the implementation and verify that it matches the proposa
 - Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
 - If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.
 - For multichain scope, use this baseline and verify its current status:
-  - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Aptos, Sonic, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
-  - V3 deprecated (legacy): Scroll, zkSync, Soneium, Metis, and Ethereum EtherFi.
+  - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
+  - V3 deprecated (legacy): Sonic, Scroll, zkSync, Metis, Soneium, Aptos, and Ethereum EtherFi.
   - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
 - Treat any V3 deployment absent from the active list as deprecated. Explain the consequences and ask which deployments to include.
 

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -13,10 +13,11 @@ Help the user question the implementation and verify that it matches the proposa
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
 - Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
 - If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.
-- For multichain scope, start from the Risk Stewards reference split and verify its current status:
-  - Active: Ethereum (Core and Lido), Polygon, Avalanche, Arbitrum, Optimism, Base, Gnosis, BNB Chain, Scroll, Linea, Sonic, Celo, Mantle, Plasma, MegaETH, Monad, and X Layer.
-  - Deprecated: Ethereum EtherFi, Metis, Soneium, and zkSync.
-    Explain the consequences and ask which deployments to include.
+- For multichain scope, use this baseline and verify its current status:
+  - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Aptos, Sonic, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
+  - V3 deprecated (legacy): Scroll, zkSync, Soneium, Metis, and Ethereum EtherFi.
+  - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
+- Treat any V3 deployment absent from the active list as deprecated. Explain the consequences and ask which deployments to include.
 
 ## Choose execution shape
 

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -11,7 +11,7 @@ Apply only the guidance relevant to the current task. Surface hidden tradeoffs a
 
 - Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
-- Identify implementation-significant choices the forum leaves unspecified, such as isolation mode, caps, or collateral settings. Explain the options and consequences, ask the writer to decide, and coordinate a forum amendment instead of inferring a default.
+- Treat any implementation argument or configuration choice absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
 - For multichain scope, list active chains separately from relevant deprecated, legacy, or partial deployments, including module availability and consequences, then ask which to include.
 
 ## Choose execution shape

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: write-aave-proposals
+description: Use automatically when creating, implementing, testing, documenting, or reviewing an Aave governance proposal. Do not use for work on the proposal generator or its features. Surface specification, execution, interface, testing, documentation, and multichain-dispatch knowledge while leaving material choices to the writer.
+---
+
+# Write Aave Proposals
+
+Apply only the guidance relevant to the current task. Surface hidden tradeoffs and recommendations; do not silently make material choices.
+
+## Reconcile scope
+
+- Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
+- Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
+- For multichain scope, list active chains separately from relevant deprecated, legacy, or partial deployments, including module availability and consequences, then ask which to include.
+
+## Choose execution shape
+
+- One payload ID with multiple actions is ordered and atomic; prefer it for dependent actions.
+- Multiple payload IDs in one governance proposal are failure-isolated but not ordered; prefer them for independent modules.
+- Separate governance proposals also separate voting and scheduling.
+- Recommend based on dependency and failure isolation, then ask when no choice was given.
+
+## Reuse contract surfaces
+
+- Address-book interfaces take priority; update the canonical interface when a method is missing instead of shadowing it locally.
+- For Aave-infrastructure contracts, add missing entries to `aave-address-book`, then propagate the revision through `aave-helpers` before using it here.
+- If the address book has no interface, a minimal local interface containing only required methods is fine.
+- Do not add a dependency solely to obtain an interface.
+- Prefer typed entries and runtime getters over recasting and hardcoded role hashes.
+- Before deploying a contract in `execute`, surface whether it is one-off or likely reusable. Keep one-offs local; recommend predeploying, verifying, and registering recurring components.
+
+## Keep implementation focused
+
+- Keep NatSpec and inline comments to intent and non-obvious invariants; keep proposal narrative in Markdown.
+
+## Test behavior
+
+- For each material change, propose an exact pre-state assertion, one execution, and a post-state assertion.
+- When rewriting a configuration, identify untouched fields at risk and test selected unchanged fields.
+- Inspect generated diffs and events; flag missing instrumentation instead of treating an absent diff as proof of no change.
+
+## Write Markdown
+
+- Use the current generator skeleton and References format; regenerate instead of handcrafting the layout.
+- Fetch the Discourse topic through its `.json` URL, save the post content, and mechanically diff it with the Markdown after normalizing only generator-imposed structure and explicit Disclaimer removal. Content differences are not acceptable.
+- Keep generated repository links on `main` before merge so the IPFS workflow can pin the final commit.
+- Diff against both the generator skeleton and saved forum content, accounting for every difference.
+
+## Validate large cross-chain dispatches
+
+- Simulate the complete Ethereum `executeProposal` from cold state using real Governance, CrossChainController, and configured adapters rather than per-payload mocks.
+- Report gas against current constraints, `PayloadSent` count, adapter attempts, and successful destinations, distinguishing attempts from chains.
+- If results or margin are concerning, present splitting options and ask before changing the execution shape.

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -11,6 +11,7 @@ Apply only the guidance relevant to the current task. Surface hidden tradeoffs a
 
 - Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
+- Identify implementation-significant choices the forum leaves unspecified, such as isolation mode, caps, or collateral settings. Explain the options and consequences, ask the writer to decide, and coordinate a forum amendment instead of inferring a default.
 - For multichain scope, list active chains separately from relevant deprecated, legacy, or partial deployments, including module availability and consequences, then ask which to include.
 
 ## Choose execution shape

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -37,7 +37,6 @@ actions[0] = GovV3Helpers.buildAction(payloadB);
 GovV3Helpers.createPayload(actions);
 ```
 
-- Separate governance proposals also separate voting and scheduling.
 - Recommend based on dependency and failure isolation, then ask when no choice was given.
 
 ## Reuse contract surfaces

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -17,7 +17,7 @@ Help the user question the implementation and verify that it matches the proposa
   - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
   - V3 deprecated (legacy): Sonic, Scroll, zkSync, Metis, Soneium, Aptos, and Ethereum EtherFi.
   - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
-- Treat any V3 deployment absent from the active list as deprecated. Explain the consequences and ask which deployments to include.
+- Treat any V3 deployment absent from the active list as deprecated. Deprecated status is context, not a prohibition: inform the user and let them decide whether to include the deployment.
 
 ## Bootstrap and choose custom execution shape
 

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -11,13 +11,32 @@ Apply only the guidance relevant to the current task. Surface hidden tradeoffs a
 
 - Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
-- Treat any implementation argument or configuration choice absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
-- For multichain scope, list active chains separately from relevant deprecated, legacy, or partial deployments, including module availability and consequences, then ask which to include.
+- Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
+- For multichain scope, start from the set used by the Risk Stewards AIP: Ethereum (Core, Lido, and EtherFi), Polygon, Avalanche, Arbitrum, Optimism, Base, Gnosis, BNB Chain, Scroll, Linea, Sonic, Celo, Mantle, Plasma, MegaETH, Monad, and X Layer. Check whether it has changed, list relevant deprecated, legacy, or partial deployments separately with their consequences, then ask which chains to include.
 
 ## Choose execution shape
 
-- One payload ID with multiple actions is ordered and atomic; prefer it for dependent actions.
-- Multiple payload IDs in one governance proposal are failure-isolated but not ordered; prefer them for independent modules.
+- One `createPayload` call with multiple actions creates one payload ID. Actions execute sequentially and atomically: one revert rolls back the whole payload. Prefer this for dependent actions.
+
+```solidity
+IPayloadsControllerCore.ExecutionAction[] memory actions =
+  new IPayloadsControllerCore.ExecutionAction[](2);
+actions[0] = GovV3Helpers.buildAction(payloadA);
+actions[1] = GovV3Helpers.buildAction(payloadB);
+GovV3Helpers.createPayload(actions);
+```
+
+- Separate `createPayload` calls create separate payload IDs. Their executions are failure-isolated and have no ordering guarantee, even when included in one governance proposal. Prefer this for independent actions.
+
+```solidity
+IPayloadsControllerCore.ExecutionAction[] memory actions =
+  new IPayloadsControllerCore.ExecutionAction[](1);
+actions[0] = GovV3Helpers.buildAction(payloadA);
+GovV3Helpers.createPayload(actions);
+actions[0] = GovV3Helpers.buildAction(payloadB);
+GovV3Helpers.createPayload(actions);
+```
+
 - Separate governance proposals also separate voting and scheduling.
 - Recommend based on dependency and failure isolation, then ask when no choice was given.
 
@@ -32,7 +51,7 @@ Apply only the guidance relevant to the current task. Surface hidden tradeoffs a
 
 ## Keep implementation focused
 
-- Keep NatSpec and inline comments to intent and non-obvious invariants; keep proposal narrative in Markdown.
+- Keep NatSpec and inline comments to intent and non-obvious invariants.
 
 ## Test behavior
 

--- a/.agents/skills/write-aave-proposals/SKILL.md
+++ b/.agents/skills/write-aave-proposals/SKILL.md
@@ -5,7 +5,7 @@ description: Use automatically when creating, implementing, testing, documenting
 
 # Write Aave Proposals
 
-Apply only the guidance relevant to the current task. Surface hidden tradeoffs and recommendations; do not silently make material choices.
+Help the user question the implementation and verify that it matches the proposal's actual intent; do not put the agent on autopilot or impose opinionated choices.
 
 ## Reconcile scope
 

--- a/.agents/skills/write-aave-proposals/references/asset-listing.md
+++ b/.agents/skills/write-aave-proposals/references/asset-listing.md
@@ -6,3 +6,5 @@ Before treating a new asset listing as ready for implementation or review, verif
 - the LlamaRisk risk assessment.
 
 Confirm that each assessment covers the asset and deployment being listed. If either assessment is missing, incomplete, unreferenced, or out of scope, surface it as a blocker and ask the user to resolve it before proceeding.
+
+Do not assume an assessment is internally correct because it is authoritative. For every risk parameter and rationale, independently derive from protocol behavior how increasing or decreasing the parameter changes the claimed risk, compare the current and proposed values, and record the result even when they agree. Treat a directional contradiction as unresolved until the risk assessment is corrected or clarified.

--- a/.agents/skills/write-aave-proposals/references/asset-listing.md
+++ b/.agents/skills/write-aave-proposals/references/asset-listing.md
@@ -7,6 +7,6 @@ Before treating a new asset listing as ready for implementation or review, verif
 
 Confirm that each assessment covers the asset and deployment being listed. If either assessment is missing, incomplete, unreferenced, or out of scope, surface it as a blocker and ask the user to resolve it before proceeding.
 
-For V4 listings, make the Tokenization Spoke choice explicit. Under the current convention, prefer deploying and registering one even for a non-borrowable asset or when tokenization is not intended, with an add cap of 0. If omitted, surface the deviation and confirm whether this convention has been superseded; do not treat the transitional practice as a permanent protocol invariant.
+For V4 listings, discuss the Tokenization Spoke choice with the user and explain the current implicit convention: prefer deploying and registering one even for a non-borrowable asset or when tokenization is not intended, with an add cap of 0.
 
 Do not assume an assessment is internally correct because it is authoritative. For every risk parameter and rationale, independently derive from protocol behavior how increasing or decreasing the parameter changes the claimed risk, compare the current and proposed values, and record the result even when they agree. Treat a directional contradiction as unresolved until the risk assessment is corrected or clarified.

--- a/.agents/skills/write-aave-proposals/references/asset-listing.md
+++ b/.agents/skills/write-aave-proposals/references/asset-listing.md
@@ -7,4 +7,6 @@ Before treating a new asset listing as ready for implementation or review, verif
 
 Confirm that each assessment covers the asset and deployment being listed. If either assessment is missing, incomplete, unreferenced, or out of scope, surface it as a blocker and ask the user to resolve it before proceeding.
 
+For V4 listings, make the Tokenization Spoke choice explicit. Under the current convention, prefer deploying and registering one even for a non-borrowable asset or when tokenization is not intended, with an add cap of 0. If omitted, surface the deviation and confirm whether this convention has been superseded; do not treat the transitional practice as a permanent protocol invariant.
+
 Do not assume an assessment is internally correct because it is authoritative. For every risk parameter and rationale, independently derive from protocol behavior how increasing or decreasing the parameter changes the claimed risk, compare the current and proposed values, and record the result even when they agree. Treat a directional contradiction as unresolved until the risk assessment is corrected or clarified.

--- a/.agents/skills/write-aave-proposals/references/asset-listing.md
+++ b/.agents/skills/write-aave-proposals/references/asset-listing.md
@@ -1,0 +1,8 @@
+# Asset listings
+
+Before treating a new asset listing as ready for implementation or review, verify that both assessments are complete and directly referenced by the proposal specification or forum post:
+
+- the Aave Labs technical assessment;
+- the LlamaRisk risk assessment.
+
+Confirm that each assessment covers the asset and deployment being listed. If either assessment is missing, incomplete, unreferenced, or out of scope, surface it as a blocker and ask the user to resolve it before proceeding.

--- a/.agents/skills/write-aave-proposals/references/proposal-authoring.md
+++ b/.agents/skills/write-aave-proposals/references/proposal-authoring.md
@@ -5,6 +5,7 @@ Help the user question the implementation and verify that it matches the proposa
 ## Reconcile scope
 
 - Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
+- Build a complete before-and-after inventory of every material configuration change, recording its current onchain value, protocol scope, directional effect, and written rationale. Verify each row against actual protocol behavior and identify existing assets or positions affected by shared settings; do not sample changes or stop after finding the first issues. Treat any conflict between the value, rationale, and intended outcome as unresolved until the authoritative source reconciles it.
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
 - Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
 - If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.

--- a/.agents/skills/write-aave-proposals/references/proposal-authoring.md
+++ b/.agents/skills/write-aave-proposals/references/proposal-authoring.md
@@ -12,7 +12,6 @@ Help the user question the implementation and verify that it matches the proposa
   - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
   - V3 deprecated (legacy): Sonic, Scroll, zkSync, Metis, Soneium, Aptos, and Ethereum EtherFi.
   - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
-- Treat any V3 deployment absent from the active list as deprecated. Deprecated status is context, not a prohibition: inform the user and let them decide whether to include the deployment.
 
 ## Validate the specification before implementation
 

--- a/.agents/skills/write-aave-proposals/references/proposal-authoring.md
+++ b/.agents/skills/write-aave-proposals/references/proposal-authoring.md
@@ -1,0 +1,74 @@
+# Proposal authoring
+
+Help the user question the implementation and verify that it matches the proposal's actual intent; do not put the agent on autopilot or impose opinionated choices.
+
+## Reconcile scope
+
+- Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
+- Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
+- Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
+- If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.
+- For multichain scope, use this baseline and verify its current status:
+  - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
+  - V3 deprecated (legacy): Sonic, Scroll, zkSync, Metis, Soneium, Aptos, and Ethereum EtherFi.
+  - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
+- Treat any V3 deployment absent from the active list as deprecated. Deprecated status is context, not a prohibition: inform the user and let them decide whether to include the deployment.
+
+## Bootstrap and choose custom execution shape
+
+Always bootstrap the proposal with the repository generator. If it has no premade setup for the required action, preserve the generated structure and build the custom implementation from it. For custom proposals, choose how to register multiple actions:
+
+- One `createPayload` call with multiple actions creates one payload ID. Actions execute sequentially and atomically: one revert rolls back the whole payload. Prefer this for dependent actions.
+
+```solidity
+IPayloadsControllerCore.ExecutionAction[] memory actions =
+  new IPayloadsControllerCore.ExecutionAction[](2);
+actions[0] = GovV3Helpers.buildAction(payloadA);
+actions[1] = GovV3Helpers.buildAction(payloadB);
+GovV3Helpers.createPayload(actions);
+```
+
+- Separate `createPayload` calls create separate payload IDs. Their executions are failure-isolated and have no ordering guarantee, even when included in one governance proposal. Prefer this for independent actions.
+
+```solidity
+IPayloadsControllerCore.ExecutionAction[] memory actions =
+  new IPayloadsControllerCore.ExecutionAction[](1);
+actions[0] = GovV3Helpers.buildAction(payloadA);
+GovV3Helpers.createPayload(actions);
+actions[0] = GovV3Helpers.buildAction(payloadB);
+GovV3Helpers.createPayload(actions);
+```
+
+- Recommend based on dependency and failure isolation, then ask when no choice was given.
+
+## Reuse contract surfaces
+
+- Address-book interfaces take priority; update the canonical interface when a method is missing instead of shadowing it locally.
+- For Aave-infrastructure contracts, add missing entries to `aave-address-book`, then propagate the revision through `aave-helpers` before using it here.
+- If the address book has no interface, a minimal local interface containing only required methods is fine.
+- Do not add a dependency solely to obtain an interface.
+- Prefer typed entries and runtime getters over recasting and hardcoded role hashes.
+- Before deploying a contract in `execute`, surface whether it is one-off or likely reusable. Keep one-offs local; recommend predeploying, verifying, and registering recurring components.
+
+## Keep implementation focused
+
+- Keep NatSpec and inline comments to intent and non-obvious invariants.
+
+## Test behavior
+
+- For each material change, propose an exact pre-state assertion, one execution, and a post-state assertion.
+- When rewriting a configuration, identify untouched fields at risk and test selected unchanged fields.
+- Inspect generated diffs and events; flag missing instrumentation instead of treating an absent diff as proof of no change.
+
+## Write Markdown
+
+- Use the current generator skeleton and References format; regenerate instead of handcrafting the layout.
+- Fetch the Discourse topic through its `.json` URL, save the post content, and mechanically diff it with the Markdown after normalizing only generator-imposed structure and explicit Disclaimer removal. Content differences are not acceptable.
+- Keep generated repository links on `main` before merge so the IPFS workflow can pin the final commit.
+- Diff against both the generator skeleton and saved forum content, accounting for every difference.
+
+## Validate large cross-chain dispatches
+
+- Simulate the complete Ethereum `executeProposal` from cold state using real Governance, CrossChainController, and configured adapters rather than per-payload mocks.
+- Report gas against current constraints, `PayloadSent` count, adapter attempts, and successful destinations, distinguishing attempts from chains.
+- If results or margin are concerning, present splitting options and ask before changing the execution shape.

--- a/.agents/skills/write-aave-proposals/references/proposal-authoring.md
+++ b/.agents/skills/write-aave-proposals/references/proposal-authoring.md
@@ -7,13 +7,18 @@ Help the user question the implementation and verify that it matches the proposa
 - Compare the forum, deployments, config, payloads, tests, and Markdown; surface every mismatch.
 - Build a complete before-and-after inventory of every material configuration change, recording its current onchain value, protocol scope, directional effect, and written rationale. Verify each row against actual protocol behavior and identify existing assets or positions affected by shared settings; do not sample changes or stop after finding the first issues. Treat any conflict between the value, rationale, and intended outcome as unresolved until the authoritative source reconciles it.
 - Check every address-book address against addresses explicitly named in the forum. If they differ, identify the correct target and tell the user to coordinate a forum amendment before syncing code and Markdown.
-- Treat any function argument passed by the implementation but absent from the specification as an unresolved requirement. Surface it, explain its consequences, and ask the writer to amend the specification before choosing a value.
 - If any information appears outdated, explain what likely changed and ask the user before updating the source or implementation with current information.
 - For multichain scope, use this baseline and verify its current status:
   - V3 active: Ethereum (Core, Prime, and Horizon), Plasma, Avalanche, BNB Chain, Gnosis, Monad, Base, Arbitrum, Mantle, Ink, X Layer, Polygon, Linea, Optimism, MegaETH, and Celo.
   - V3 deprecated (legacy): Sonic, Scroll, zkSync, Metis, Soneium, Aptos, and Ethereum EtherFi.
   - V4 active: Ethereum and Avalanche. No V4 deployments are deprecated.
 - Treat any V3 deployment absent from the active list as deprecated. Deprecated status is context, not a prohibition: inform the user and let them decide whether to include the deployment.
+
+## Validate the specification before implementation
+
+If no authoritative specification exists for the current governance stage, stop. When subagents are available and authorized, give a context-isolated subagent only the authoritative specification sources and relevant protocol or generator interfaces. Ask it to audit completeness without implementing, choosing values, or seeing suspected gaps.
+
+Require a matrix mapping every required payload field and implicit protocol side effect to its scope, current value, proposed value, units, source, and rationale. Distinguish explicit requirements from derived values and assumptions. Treat missing material inputs, contradictory sources, and undisclosed side effects as blockers until the authoritative specification resolves them.
 
 ## Bootstrap and choose custom execution shape
 

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
Adds a repository-local router for Aave governance proposal guidance. Shared proposal-authoring rules live in a common reference, while proposal-specific guidance is loaded only when it matches the work.

Before implementation, the shared guidance requires a context-isolated specification audit that maps every required payload field and implicit protocol side effect to its scope, current and proposed values, units, source, and rationale. Missing material inputs, contradictory sources, and undisclosed side effects remain blockers.

The shared review also requires a complete before-and-after inventory of material configuration changes, including scope, directional effect, and rationale. The asset-listing specialist requires completed Aave Labs and LlamaRisk assessments, independently validates every risk parameter and rationale, and prompts discussion of the current V4 convention of deploying and registering a Tokenization Spoke with zero add cap when tokenization is not intended.

A Claude-compatible symlink exposes the same canonical skill without duplicating it.