### PR TITLE
Use published emode constant in xlayer usdc listing

### DIFF
--- a/diffs/AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_before_AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_after.md
+++ b/diffs/AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_before_AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_after.md
@@ -125,13 +125,13 @@
 | 12 | CollateralConfigurationChanged(asset: 0xB6CEceAB302E2E4948951eE7843FC24E92933061 (symbol: USDC), ltv: 7500, liquidationThreshold: 7800, liquidationBonus: 10750) |
 | 13 | LiquidationProtocolFeeChanged(asset: 0xB6CEceAB302E2E4948951eE7843FC24E92933061 (symbol: USDC), oldFee: 0, newFee: 1000) |
 | 14 | EModeCategoryAdded(categoryId: 1, ltv: 7800, liquidationThreshold: 8100, liquidationBonus: 10600, oracle: 0x0000000000000000000000000000000000000000, label: xBTC__Stablecoins) |
-| 15 | topics: `0xea07f8a4f488dcc1dc8c27b9c526ac8ba2d04b8024e206616f306c51d9b16826`, `0x0000000000000000000000000000000000000000000000000000000000000001`, data: `0x0000000000000000000000000000000000000000000000000000000000000000` |
+| 15 | EModeCategoryIsolationChanged(categoryId: 1, isolated: false) |
 | 16 | EModeCategoryAdded(categoryId: 2, ltv: 7800, liquidationThreshold: 8000, liquidationBonus: 10600, oracle: 0x0000000000000000000000000000000000000000, label: xETH__Stablecoins) |
-| 17 | topics: `0xea07f8a4f488dcc1dc8c27b9c526ac8ba2d04b8024e206616f306c51d9b16826`, `0x0000000000000000000000000000000000000000000000000000000000000002`, data: `0x0000000000000000000000000000000000000000000000000000000000000000` |
+| 17 | EModeCategoryIsolationChanged(categoryId: 2, isolated: false) |
 | 18 | EModeCategoryAdded(categoryId: 3, ltv: 6500, liquidationThreshold: 7000, liquidationBonus: 10750, oracle: 0x0000000000000000000000000000000000000000, label: xSOL__Stablecoins) |
-| 19 | topics: `0xea07f8a4f488dcc1dc8c27b9c526ac8ba2d04b8024e206616f306c51d9b16826`, `0x0000000000000000000000000000000000000000000000000000000000000003`, data: `0x0000000000000000000000000000000000000000000000000000000000000000` |
+| 19 | EModeCategoryIsolationChanged(categoryId: 3, isolated: false) |
 | 20 | EModeCategoryAdded(categoryId: 4, ltv: 5000, liquidationThreshold: 5500, liquidationBonus: 11000, oracle: 0x0000000000000000000000000000000000000000, label: WOKB__Stablecoins) |
-| 21 | topics: `0xea07f8a4f488dcc1dc8c27b9c526ac8ba2d04b8024e206616f306c51d9b16826`, `0x0000000000000000000000000000000000000000000000000000000000000004`, data: `0x0000000000000000000000000000000000000000000000000000000000000000` |
+| 21 | EModeCategoryIsolationChanged(categoryId: 4, isolated: false) |
 | 22 | AssetCollateralInEModeChanged(asset: 0xB6CEceAB302E2E4948951eE7843FC24E92933061 (symbol: USDC), categoryId: 1, collateral: false) |
 | 23 | AssetBorrowableInEModeChanged(asset: 0xB6CEceAB302E2E4948951eE7843FC24E92933061 (symbol: USDC), categoryId: 1, borrowable: true) |
 | 24 | AssetCollateralInEModeChanged(asset: 0xB6CEceAB302E2E4948951eE7843FC24E92933061 (symbol: USDC), categoryId: 2, collateral: false) |

--- a/src/20260818_AaveV3XLayer_AaveV3XLayerUSDCListing/AaveV3XLayer_AaveV3XLayerUSDCListing_20260818.sol
+++ b/src/20260818_AaveV3XLayer_AaveV3XLayerUSDCListing/AaveV3XLayer_AaveV3XLayerUSDCListing_20260818.sol
@@ -139,8 +139,7 @@ contract AaveV3XLayer_AaveV3XLayerUSDCListing_20260818 is AaveV3PayloadXLayer {
     });
     assetEModeUpdates[4] = IAaveV3ConfigEngine.AssetEModeUpdate({
       asset: USDC,
-      // AaveV3XLayerEModes.PT_USDG_29OCT2026__USDT_USDG_GHO
-      eModeCategory: 7,
+      eModeCategory: AaveV3XLayerEModes.PT_USDG_29OCT2026__USDT_USDG_GHO,
       borrowable: EngineFlags.ENABLED,
       collateral: EngineFlags.DISABLED,
       ltvzero: EngineFlags.DISABLED

--- a/src/20260818_AaveV3XLayer_AaveV3XLayerUSDCListing/AaveV3XLayer_AaveV3XLayerUSDCListing_20260818.t.sol
+++ b/src/20260818_AaveV3XLayer_AaveV3XLayerUSDCListing/AaveV3XLayer_AaveV3XLayerUSDCListing_20260818.t.sol
@@ -90,7 +90,7 @@ contract AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_Test is ProtocolV3TestBas
       AaveV3XLayerEModes.xETH__USDT_USDG_GHO,
       AaveV3XLayerEModes.xSOL__USDT_USDG_GHO,
       AaveV3XLayerEModes.WOKB__USDT_USDG_GHO,
-      _findEModeCategoryId('PT_USDG__Stablecoins')
+      AaveV3XLayerEModes.PT_USDG_29OCT2026__USDT_USDG_GHO
     ];
 
     for (uint256 i = 0; i < eModeIds.length; i++) {
@@ -140,8 +140,7 @@ contract AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_Test is ProtocolV3TestBas
   function test_eModeBorrowUsdc() public {
     GovV3Helpers.executePayload(vm, address(proposal));
 
-    uint8 eModeId = _findEModeCategoryId('PT_USDG__Stablecoins');
-    assertEq(eModeId, 7, 'hardcoded eMode id should match the PT_USDG__Stablecoins label');
+    uint8 eModeId = AaveV3XLayerEModes.PT_USDG_29OCT2026__USDT_USDG_GHO;
 
     address user = makeAddr('eModeBorrower');
     address collateral = PT_USDG_29OCT2026;
@@ -208,21 +207,12 @@ contract AaveV3XLayer_AaveV3XLayerUSDCListing_20260818_Test is ProtocolV3TestBas
       110_00
     );
     _assertEModeLabelAndParams(
-      _findEModeCategoryId('PT_USDG__Stablecoins'),
+      AaveV3XLayerEModes.PT_USDG_29OCT2026__USDT_USDG_GHO,
       'PT_USDG__Stablecoins',
       92_66,
       94_66,
       102_34
     );
-  }
-
-  function _findEModeCategoryId(string memory label) internal view returns (uint8) {
-    for (uint8 i = 1; i < 255; i++) {
-      if (keccak256(bytes(AaveV3XLayer.POOL.getEModeCategoryLabel(i))) == keccak256(bytes(label))) {
-        return i;
-      }
-    }
-    revert('eMode category not found');
   }
 
   function _assertEModeLabelAndParams(


### PR DESCRIPTION
g checklist is only relevant for proposal PRs. Remove this section if not applicable.

### Pre-review checklist:

- [x] I have run a spell check on the write-up and made sure no typos exist.
- [x] References to Snapshot/governance forum are correct on the AIP. If no snapshot exists, make sure no TODO's exist.
- [x] The specification on the writeup is aligned with the forum, snapshot, and the payload contract. If there are any changes, they are explicitly mentioned/communicated.
- [x] Minimal tests exist, and the snapshot diff report generated is the latest one and aligned with the payload.
- [x] If deploy scripts are manually updated from the generated ones, I have carefully validated that they are correct, including the deploy commands and the proposal-creation script.
- [x] If the aave-helpers submodule is updated, I have validated it is pointing to the latest version.
- [x] I have validated that no unused files and imports are being added.
- [x] For an asset listing, the write-up includes a detailed specification of the price feed used, CAPO adapters (with each CAPO layer described separately), and eModes (with tables) if changed.
- [x] Wherever possible, I have validated that addresses from the address book are used instead of raw addresses.

